### PR TITLE
Improvements to the spell checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Call avocado to run check_modulemd.py, providing the path to the modulemd file u
 
     avocado run ./check_modulemd.py --mux-inject 'run:modulemd:/path/to/modulemd.yaml'
 
+In order to use a custom list of packaging jargon in the spell-checker, a
+second parameter must be passed. This can be done by using a multiplexer
+yaml file like the one used in this example:
+
+    avocado run ./check_modulemd.py -m examples-testdata/params-checkmmd.yaml
+
 For convenience during development of the test script, a wrapper script is
 provided that simplifies passing the required parameter:
 

--- a/check_modulemd.py
+++ b/check_modulemd.py
@@ -37,6 +37,18 @@ class ModulemdTest(Test):
         except:
             self.error("Could not load modulemd file %s" % mdfile)
 
+        # Infer the module name from the mdfile name and check that it is sane
+        mdfileModuleName, mdfileExtension = os.path.basename(mdfile).split('.', 1)
+        if (mdfileExtension != 'yaml') and (mdfileExtension != 'yml'):
+            self.error("modulemd file %s must have a .y[a]ml extension" % mdfile)
+        if mmd.name == '':
+            # The name can be missing from the metadata because the builder
+            # knows how to infer it
+            mmd.name = mdfileModuleName
+        elif mmd.name != mdfileModuleName:
+            self.error("modulemd file name %s and module name %s do not match" % (
+                mdfileModuleName, mmd.name))
+
         self.mdfile = mdfile
         self.mmd = mmd
 
@@ -45,6 +57,8 @@ class ModulemdTest(Test):
             if jargonfile is not None:
                 jargonfile = str(jargonfile)
                 dict = DictWithPWL("en_US", jargonfile)
+                for w in self.mmd.name.split('-'):
+                    dict.add_to_session(w)
                 self.chkr = SpellChecker(dict)
             else:
                 self.chkr = SpellChecker("en_US")

--- a/check_modulemd.py
+++ b/check_modulemd.py
@@ -3,6 +3,7 @@
 import os
 import modulemd
 from enchant.checker import SpellChecker
+from enchant import DictWithPWL
 
 from avocado import main
 from avocado import Test
@@ -38,6 +39,18 @@ class ModulemdTest(Test):
 
         self.mdfile = mdfile
         self.mmd = mmd
+
+        try:
+            jargonfile = self.params.get('jargonfile')
+            if jargonfile is not None:
+                jargonfile = str(jargonfile)
+                dict = DictWithPWL("en_US", jargonfile)
+                self.chkr = SpellChecker(dict)
+            else:
+                self.chkr = SpellChecker("en_US")
+        except:
+            self.error(
+                "Could not initialize spell checker with dictionary %s" % dict)
 
     def test_debugdump(self):
         """
@@ -111,14 +124,8 @@ class ModulemdTest(Test):
         Any spellcheck failures in description?
         """
         self.log.info("Checking for spelling errors in description")
-        dict = "en_US"
-        try:
-            chkr = SpellChecker(dict)
-        except:
-            self.error(
-                "Could not initialize spell checker with dictionary %s" % dict)
-        chkr.set_text(self.mmd.description)
-        for err in chkr:
+        self.chkr.set_text(self.mmd.description)
+        for err in self.chkr:
             self.log.warn(
                 "Potential spelling problem in description: %s" % err.word)
 
@@ -140,14 +147,8 @@ class ModulemdTest(Test):
         Any spellcheck failures in summary?
         """
         self.log.info("Checking for spelling errors in summary")
-        dict = "en_US"
-        try:
-            chkr = SpellChecker(dict)
-        except:
-            self.error(
-                "Could not initialize spell checker with dictionary %s" % dict)
-        chkr.set_text(self.mmd.summary)
-        for err in chkr:
+        self.chkr.set_text(self.mmd.summary)
+        for err in self.chkr:
             self.log.warn(
                 "Potential spelling problem in summary: %s" % err.word)
 
@@ -178,21 +179,15 @@ class ModulemdTest(Test):
         Any spellcheck failures in rationales?
         """
         self.log.info("Checking for spelling errors in component rationales")
-        dict = "en_US"
-        try:
-            chkr = SpellChecker(dict)
-        except:
-            self.error(
-                "Could not initialize spell checker with dictionary %s" % dict)
 
         for p in self.mmd.components.rpms.values():
-            chkr.set_text(p.rationale)
-            for err in chkr:
+            self.chkr.set_text(p.rationale)
+            for err in self.chkr:
                 self.log.warn("Potential spelling problem in component RPM %s rationale: %s" % (
                     p.name, err.word))
         for p in self.mmd.components.modules.values():
-            chkr.set_text(p.rationale)
-            for err in chkr:
+            self.chkr.set_text(p.rationale)
+            for err in self.chkr:
                 self.log.warn("Potential spelling problem in component module %s rationale: %s" % (
                     p.name, err.word))
 

--- a/examples-modulemd/base-runtime.yaml
+++ b/examples-modulemd/base-runtime.yaml
@@ -1,0 +1,9133 @@
+# An 'example' module; the current definition of the base-runtime module at:
+# http://pkgs.stg.fedoraproject.org/cgit/modules/base-runtime.git/plain/base-runtime.yaml
+document: modulemd
+version: 1
+data:
+    summary: The base application runtime and hardware enablement layer
+    description: >
+        A project closely linked to the Modularity Initiative, base-runtime
+        is about the defining the common shared package and feature set of
+        the operating system, providing both the hardware enablement layer
+        and the minimal application runtime environment other modules can
+        build upon.
+    license:
+        module: [ MIT ]
+    dependencies:
+        buildrequires:
+            base-runtime: master
+    references:
+        community: https://fedoraproject.org/wiki/BaseRuntime
+        documentation: https://pagure.io/base-runtime
+        tracker: https://pagure.io/base-runtime/issues
+    profiles:
+        # The default profile currently consists of the Linux kernel, the
+        # systemd init system and all the POSIX userspace utilities that
+        # are available in Fedora.
+        default:
+            rpms:
+                # at, batch
+                - at
+                # sh
+                - bash
+                # bc
+                - bc
+                # ar, nm, strings, strip
+                - binutils
+                # yacc
+                - byacc
+                # cflow
+                - cflow
+                # basename, cat, chgrp, chmod, chown, cksum, comm, cp, csplit,
+                # cut, date, dd, df, dirname, du, echo, env, expand, expr,
+                # false, fold, head, id, join, link, ln, logname, ls, mkdir,
+                # mkfifo, mv, nice, nl, nohup, od, paste, pathchk, pr, printf,
+                # pwd, rm, rmdir, sleep, sort, split, stty, tee, test,
+                # touch, tr, true, tsort, tty, uname, unexpand, uniq, unlink,
+                # wc, who
+                - coreutils
+                # crontab
+                - cronie
+                # ctags
+                - ctags
+                # cmp, diff
+                - diffutils
+                # ed
+                - ed
+                # needed buildroot
+                - fedpkg-minimal
+                # file
+                - file
+                # flex
+                - flex
+                # find, xargs
+                - findutils
+                # awk
+                - gawk
+                # cc, c89, c99
+                - gcc
+                # f95, gfortran
+                - gcc-gfortran
+                # gencat, getconf, iconv, locale, localedef
+                - glibc-common
+                # grep
+                - grep
+                # zcat
+                - gzip
+                # the Linux kernel
+                - kernel
+                # m4
+                - m4
+                # make
+                - make
+                # man
+                - man-db
+                # compress, uncompress
+                - ncompress
+                # tabs, tput
+                - ncurses
+                # patch
+                - patch
+                # fuser
+                - psmisc
+                # ps
+                - procps-ng
+                # sed
+                - sed
+                # newgrp
+                - shadow-utils
+                # uudecode, uuencode
+                - sharutils
+                # the chosen init system
+                - systemd
+                # time
+                - time
+                # cal, ipcrm, ipcs, kill, logger, mesg, more, renice, write
+                - util-linux
+                # ex, vi
+                - vim-minimal
+        buildroot:
+            # These are the rpms that will be pre-installed into the buildroot
+            # of any other module that declares a build-time dependency on this
+            # module.
+            rpms:
+                - bash
+                - bzip2
+                - coreutils
+                - cpio
+                - diffutils
+                - fedora-release
+                - findutils
+                - gawk
+                - gcc
+                - gcc-c++
+                - grep
+                - gzip
+                - info
+                - make
+                - patch
+                - redhat-rpm-config
+                - rpm-build
+                - sed
+                - shadow-utils
+                - tar
+                - unzip
+                - util-linux
+                - which
+                - xz
+        srpm-buildroot:
+            # These are the rpms that will be pre-installed into the
+            # srpm-buildroot of any other module that declares a build-time
+            # dependency on this module.
+            rpms:
+                - bash
+                - fedora-release
+                - fedpkg-minimal
+                - gnupg2
+                - redhat-rpm-config
+                - rpm-build
+                - shadow-utils
+    api:
+        rpms:
+            - at
+            - bash
+            - bc
+            - binutils
+            - byacc
+            - cflow
+            - coreutils
+            - cronie
+            - ctags
+            - diffutils
+            - ed
+            - fedpkg-minimal
+            - file
+            - flex
+            - findutils
+            - gawk
+            - gcc
+            - gcc-gfortran
+            - glibc-common
+            - grep
+            - gzip
+            - kernel
+            - m4
+            - make
+            - man-db
+            - ncompress
+            - ncurses
+            - patch
+            - psmisc
+            - procps-ng
+            - sed
+            - shadow-utils
+            - sharutils
+            - systemd
+            - time
+            - util-linux
+            - vim-minimal
+    components:
+        rpms:
+            a2ps:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8adc1734e86683e568b7ee5521575555cf32891a
+            acl:
+                rationale: Part of the first base-runtime prototype.
+                ref: bd6bf2ee1c8e596f56cba5e114fa13d5d615af4e
+            acpica-tools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 659d8804ed0a5b8c7563c07a445641d21e8e3c80
+            adwaita-icon-theme:
+                rationale: Part of the first base-runtime prototype.
+                ref: f8c995e07605104bb80d73915988c05de853d587
+            aesh:
+                rationale: Part of the first base-runtime prototype.
+                ref: cc1a9da604dde83042666c2eeb40c99f5351ec2c
+            aether:
+                rationale: Part of the first base-runtime prototype.
+                ref: b0bd40e0656ed7d189bc0b6071ef8a29d7cf1da8
+            airline:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6f14d16badb5aae3b2c3cfb16c47b939ee4fbd77
+            allegro:
+                rationale: Part of the first base-runtime prototype.
+                ref: ff39f9a6369891e1be86ff9086d99500d1d5adc7
+            alsa-lib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 15bc4520f97663ab044799b69da0ded29b92be29
+            ant:
+                rationale: Part of the first base-runtime prototype.
+                ref: 844825b03d8b05e170513cf803a8110e6c13ef9c
+            ant-antunit:
+                rationale: Part of the first base-runtime prototype.
+                ref: ad8bfe1abfb5c3bbcdda0148893eb62c6e9387ae
+            ant-contrib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7458659d083aeacf45f189a9ba635a2990b3c687
+            anthy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 815acfe239bf42b5ee2e7df4f704ec5ae701e798
+            antlr32:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2fd274dc9f2b7a27d0cac12007ecf8692d6aa956
+            antlr3:
+                rationale: Part of the first base-runtime prototype.
+                ref: e6eac621400b7122045fc63b62185294e6c45e39
+            antlr4:
+                rationale: Part of the first base-runtime prototype.
+                ref: 23805b91a57418f8e335755f45e8afa114931678
+            antlr:
+                rationale: Part of the first base-runtime prototype.
+                ref: dc4351a5941d1b82dce002e9032b132c66fb92ba
+            antlr-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0055b970f314eef690a05b723400e816ffa6fc84
+            aopalliance:
+                rationale: Part of the first base-runtime prototype.
+                ref: 205a32fffb6781db0eaa3ce8c5d95c2494354c97
+            apache-commons-beanutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 25b5cd767efc7cd0ca6de8c75d47b57626dfc7c9
+            apache-commons-chain:
+                rationale: Part of the first base-runtime prototype.
+                ref: d453650f27133e09daed5af3ab9053be80810eaf
+            apache-commons-cli:
+                rationale: Part of the first base-runtime prototype.
+                ref: 61461a075088434e4271a326d5fa9385166ccae0
+            apache-commons-codec:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3104502cda7e1e13947e1cf26e0850d165b7cb9e
+            apache-commons-collections4:
+                rationale: Part of the first base-runtime prototype.
+                ref: 23f500d1addab294c6532aa4d0c8e500a46a1e85
+            apache-commons-collections:
+                rationale: Part of the first base-runtime prototype.
+                ref: d7102c2bf6b5f225cc9544795bedb173d2b6f1f3
+            apache-commons-compress:
+                rationale: Part of the first base-runtime prototype.
+                ref: fc5aba788647805ccf281d3c7ea72232ef8ee651
+            apache-commons-configuration:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2a7a5ec2cd59ad3fc77981f268f01ba7056ed6d4
+            apache-commons-csv:
+                rationale: Part of the first base-runtime prototype.
+                ref: 019ec34a6630e3e87c11d4219ec68d9bdb8e9b95
+            apache-commons-daemon:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9c7f1298ec7edfc9c72640cf8254ca51225db3ff
+            apache-commons-dbcp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94d4109155091ee089ae3d043a578ad8c71e3de7
+            apache-commons-digester:
+                rationale: Part of the first base-runtime prototype.
+                ref: 19c5a8646347af007977ccebae90129e34f42d29
+            apache-commons-discovery:
+                rationale: Part of the first base-runtime prototype.
+                ref: 44ec5b07c70ccc56a9f6cfa149e2a7a8c27d38a0
+            apache-commons-el:
+                rationale: Part of the first base-runtime prototype.
+                ref: e08d42ae078e428a38512826cb593b15d99bae3c
+            apache-commons-email:
+                rationale: Part of the first base-runtime prototype.
+                ref: a8eb3fff11254548553113f25f3bb0d186e4eaa7
+            apache-commons-exec:
+                rationale: Part of the first base-runtime prototype.
+                ref: e8fbcb9645242b800f0ded034449f1d385270301
+            apache-commons-fileupload:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4b6b8c842f1d9151564619ad3e917e97b9e8277d
+            apache-commons-io:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3d91fb32c4c5b58bdc71700153f199c1bb2cda2b
+            apache-commons-javaflow:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5e00b3e4bd48379060e58b30240c0646892fad55
+            apache-commons-jci:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7656791ee47b387df0880cfda64c297f3a4c74cb
+            apache-commons-jexl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8b63c92208ef1e785af102f2d9f6b8b57071873f
+            apache-commons-jxpath:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1358353eb2c07c3f6ec2c02a5d5a796d2396751c
+            apache-commons-lang3:
+                rationale: Part of the first base-runtime prototype.
+                ref: d049cbfcd6de2f3be344751779bd677e60a4970e
+            apache-commons-lang:
+                rationale: Part of the first base-runtime prototype.
+                ref: e07e73d0572cbb4cf8dfd97fab8a102d9dc2bf88
+            apache-commons-logging:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1531352d0ff2d1050f9556c24e647b81405c6cff
+            apache-commons-math:
+                rationale: Part of the first base-runtime prototype.
+                ref: 63680c24865a88f8e6ff6cb6d7700c8f44a8f0b3
+            apache-commons-net:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6f02d5cabef431ef75a96a9b7579c3520ea56ac3
+            apache-commons-ognl:
+                rationale: Part of the first base-runtime prototype.
+                ref: c4c12a08c627f4321d91e159fb187fe81fbdf622
+            apache-commons-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3196615b5d047f6b63e9b3980944bada56692a5e
+            apache-commons-pool:
+                rationale: Part of the first base-runtime prototype.
+                ref: 06ccd0eef2e876c2a949d59a971c234471a36f55
+            apache-commons-validator:
+                rationale: Part of the first base-runtime prototype.
+                ref: f51fe05cc4179b86a767db86a1d61269cdb3b736
+            apache-commons-vfs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1c4bb4d8facca048bb5a7f96f0f6c623b0f2779a
+            apache-ivy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9234d02e0ad7aec57eb1cee734b441998fe7435c
+            apache-james-project:
+                rationale: Part of the first base-runtime prototype.
+                ref: f893b3cf012481d8b71f8e087230cec7645817ec
+            apache-mime4j:
+                rationale: Part of the first base-runtime prototype.
+                ref: da54ccca7c4ec80cada219f19763d97e92e50f1d
+            apache-mina:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7483bc4a25aa0ec633f05a93f41cfd9e5481018b
+            apache-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 948238632912444b33c6b2765e64daf6c536fd67
+            apache-poi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0305b354780285c702ed02dd0ec68d1ef54bdb14
+            apache-rat:
+                rationale: Part of the first base-runtime prototype.
+                ref: ee32c0ee2e601c2fe738cf3a0fdd6708e766b7d4
+            apache-resource-bundles:
+                rationale: Part of the first base-runtime prototype.
+                ref: 006d395c701a1075c9e0e7f0c7c722acff0df749
+            apache-sshd:
+                rationale: Part of the first base-runtime prototype.
+                ref: f2456d06e371252d141a3616af4d5496069bd1d9
+            apiviz:
+                rationale: Part of the first base-runtime prototype.
+                ref: 41abfab4407a8cffd05079c1d1e798f177e00364
+            apr:
+                rationale: Part of the first base-runtime prototype.
+                ref: ac217be647c71ceaa3efd83d3df795eae8b52b1d
+            apr-util:
+                rationale: Part of the first base-runtime prototype.
+                ref: c0ba237695ffa607b5f08284f3c0ec2044ca2c6f
+            aqute-bnd:
+                rationale: Part of the first base-runtime prototype.
+                ref: ef5b91d76aef0f01f51ab895cbee0741e9dfdf69
+            args4j:
+                rationale: Part of the first base-runtime prototype.
+                ref: 619b0082606fa6b8fade5af794e528c1c4462518
+            argyllcms:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4cec5aab8470dcb7435a6608107ae90283fc21e5
+            aries-blueprint-annotation-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4e25144564e7a733bc994e2c4a5a4597fc305d3a
+            aries-blueprint-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 221a65e55b054d24a3ec6e170d2f705e364f8b59
+            aries-blueprint-cm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 695ec946bd28bbce0b6671c4d4bb009daea321e2
+            aries-blueprint-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: ca77228695dba04db8132869d954102a8f10fe3f
+            aries-blueprint-parser:
+                rationale: Part of the first base-runtime prototype.
+                ref: f898faa592ab252de5ea7acd5250b5d27de677f2
+            aries-proxy-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 41a4d0ed48d0f1774184300ce8bc45e43d58995b
+            aries-proxy-impl:
+                rationale: Part of the first base-runtime prototype.
+                ref: ba8f91a2bc3fc22b36ac5309a7fbce21b7046229
+            aries-quiesce-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 592389d8403a468096eedb8c56ae76f03fca4694
+            aries-util:
+                rationale: Part of the first base-runtime prototype.
+                ref: d19ba9aca73d0d35597b2070355124c1709db5e5
+            armadillo:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9fb7e9117ffa51dfe693d05b96480933432970a0
+            arpack:
+                rationale: Part of the first base-runtime prototype.
+                ref: 60c4d0ef0b7666a9dbc72eb2d62e34d23fde07ed
+            arquillian-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: 58c54636dd711b66e625a661a5a127c4c5d1745e
+            artemis:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9d84cf39f9d1e294db965b0017fb4ee1a49709cf
+            arts:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6fad7a5b224548ba94984b6a7d61e98b20d2dcdc
+            asciidoc:
+                rationale: Part of the first base-runtime prototype.
+                ref: e8ce7264a2e31b2a4accc87b57e0712b336b9306
+            aspectjweaver:
+                rationale: Part of the first base-runtime prototype.
+                ref: b20f208e2dba421e846c0bc3c7e04e4e1eb839bc
+            aspell:
+                rationale: Part of the first base-runtime prototype.
+                ref: a33a559d06af827889d2ba1249a2df171b112fcb
+            aspell-en:
+                rationale: Part of the first base-runtime prototype.
+                ref: 972659bcb12c48a93688df272aae0e7e1c70b699
+            assertj-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: c237899b6d5a24f89e5e693231823fc0c9a8e0be
+            at:
+                rationale: Part of the first base-runtime prototype.
+                ref: aa74292e24a20f8f3f8ab49bc338233b2bc7542f
+            atinject:
+                rationale: Part of the first base-runtime prototype.
+                ref: 14c1170f0dac764725c2d1b08829717ea1e7e4a0
+            atk:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0168e9654e5e31a9a962259a3a044e3fc28c53e4
+            atkmm:
+                rationale: Part of the first base-runtime prototype.
+                ref: b95281f295b4bde659821d2d83d612ab198bcaf0
+            atlas:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6af83c0231b358adbc6fdea346181942d3d89379
+            at-spi2-atk:
+                rationale: Part of the first base-runtime prototype.
+                ref: b6dc58c66a8922a64276c7a680800d5b7d40de85
+            at-spi2-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: d8bda6ed0c7b4b4ebd6bdfc8af9ee5b8c8cb51e7
+            attica:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4f1cd26bbdf6eb8ad149723ab5e272560bd20c23
+            attr:
+                rationale: Part of the first base-runtime prototype.
+                ref: 970c2cb3cdfa1220431793b4c3b2573bbfb50414
+            audiofile:
+                rationale: Part of the first base-runtime prototype.
+                ref: b441c769b5bcf08ea2797ef291336559df75a21e
+            audit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 627d33b583c7afc8a552a99f4ccd587b20e72922
+            augeas:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9e2e331c525319c124b60aa78fedb6a56e374516
+            authconfig:
+                rationale: Part of the first base-runtime prototype.
+                ref: 18ba98d1e80b0e9887affae41103b2f8acd1c9c6
+            auto:
+                rationale: Part of the first base-runtime prototype.
+                ref: 65682eaf67f560e3fca672a79454c544f0e4aa4d
+            autoconf213:
+                rationale: Part of the first base-runtime prototype.
+                ref: b07ca136ecac59077a1bd6eb6f2bc3e0c21818c9
+            autoconf:
+                rationale: Part of the first base-runtime prototype.
+                ref: a2a1a48584d78dbe56673228034436b9f0473e03
+            autoconf-archive:
+                rationale: Part of the first base-runtime prototype.
+                ref: bf26e731e00712ca4dd510da5ecd22fee78da505
+            autogen:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3f0a4cf12e6c00839cf5d10b70e4422047ee18fd
+            automake:
+                rationale: Part of the first base-runtime prototype.
+                ref: c552a0666629018e39c531aeb10c97b12167bbf9
+            automoc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9457fd5f1f4da3d2d17045a3b5fea1ca163ac22f
+            autotrace:
+                rationale: Part of the first base-runtime prototype.
+                ref: 72a936af8c0dd85e4c479f70df681935c853bb27
+            avahi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 52f0d526d86dd02998ca2ce6c8083e6e23a304c2
+            avalon-framework:
+                rationale: Part of the first base-runtime prototype.
+                ref: 53f1371b114ad2f3204ff5bb1e78c5405bb62b0e
+            avalon-logkit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4d233510dd2c3b789fd5176596e2ee9f0cb202e5
+            aws-sdk-java:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1724f3272c214045078918a8cea16744ec33b3c2
+            axis:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5f6e7d5da620fed1e6ebba813abd3acd007e4445
+            babel:
+                rationale: Part of the first base-runtime prototype.
+                ref: b234f5934d709099d8d0b6fa591349f1829a2e22
+            babeltrace:
+                rationale: Part of the first base-runtime prototype.
+                ref: b816536844d419a4a60b5a18bfab1ac9a3dce11b
+            bakefile:
+                rationale: Part of the first base-runtime prototype.
+                ref: f19236c472a833c758592ab642a5c80433e9ab8f
+            base64coder:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7b02f7eeb2415ed7be8ac77fcaa959ff2515b50d
+            basesystem:
+                rationale: Part of the first base-runtime prototype.
+                ref: 17e46926b8bd259d1b72b5337425a53031a7f1b8
+            bash:
+                rationale: Part of the first base-runtime prototype.
+                ref: b1104ec130056866f3bdce51a3f77685b702fbde
+            bash-completion:
+                rationale: Part of the first base-runtime prototype.
+                ref: ec12812d358c7436a47eaeb0553b25bb3a768af9
+            batik:
+                rationale: Part of the first base-runtime prototype.
+                ref: d834bae74a053be34e941d291ca79fe77ba9cc11
+            bc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7997fbadf8a1cfbe5a7772238d572d5aec0527d9
+            bcache-tools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 81890011b144465f7b89b72ec557900ee4b02449
+            bcel:
+                rationale: Part of the first base-runtime prototype.
+                ref: 615c6ca10e507243da5c411ff80a8e3bafbd5289
+            bean-validation-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9f3721e076bd334f2b94811d38e3da654441b61c
+            bea-stax:
+                rationale: Part of the first base-runtime prototype.
+                ref: 68e8d6573427cfafdb6c10e79db00e28efbcc6cc
+            beust-jcommander:
+                rationale: Part of the first base-runtime prototype.
+                ref: b45707008b569b0823187379fa92c8470864c2af
+            bind:
+                rationale: Part of the first base-runtime prototype.
+                ref: 27a8e54aa71891dd60cfc8c07e2458a1f5c5e729
+            bind99:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9e78b96ca23be7a17a0272ee307922f13ba774d2
+            binutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: e9bb253066ff298fd88e54f61750ea949d55e452
+            bison:
+                rationale: Part of the first base-runtime prototype.
+                ref: 42a4506120039c18e5fca34424f59947f40d5959
+            bitstream-vera-fonts:
+                rationale: Part of the first base-runtime prototype.
+                ref: 18907f7dc08267af6688f2d4ddf931946086c469
+            bluez:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8c2188f721f7048ef708cfb08930d466587bf6c7
+            boilerpipe:
+                rationale: Part of the first base-runtime prototype.
+                ref: e9699cc64fc33c3cdcb2d8ad2d1a4c55a4ed37c6
+            boost:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0b594070c737c033c15c16f2ee4a2df1a4981ef8
+            botan:
+                rationale: Part of the first base-runtime prototype.
+                ref: 84dde5b3f2f6b4d1c93498108d66e6b3e2aa6df2
+            bouncycastle:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2fe69cd710dec2565fe6cfaa118f46c806b40d6a
+            bouncycastle-mail:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6a26bdb5f93b52e0bcad20d0573e1bf85365a4b4
+            bouncycastle-pg:
+                rationale: Part of the first base-runtime prototype.
+                ref: f6a766401c3c37a5251048045f11335b4b51eb07
+            bouncycastle-pkix:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4c64b20a6be2938effec2b5da7f58878b8338d95
+            breeze-icon-theme:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2c49513cd9889d732e259faada2cbed356423096
+            bridge-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3de559655b17892ad46824c3f28dbc35962aa244
+            brltty:
+                rationale: Part of the first base-runtime prototype.
+                ref: fb5ae6819edb214a54575bb160268b91c1b94547
+            bsf:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3b72da7f338b0317e7b621687e0ca3359fdf62ef
+            bsh:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7fad1b4523dbe9e5702ab28913d5a0b81da4c6f3
+            btrfs-progs:
+                rationale: Part of the first base-runtime prototype.
+                ref: e7ba37128a6ed9eb76af4a819731d88c534f2135
+            buildnumber-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9e7a0a0bf60c3d47f37d9ea2e80afe5fa3c6a5e0
+            bullet:
+                rationale: Part of the first base-runtime prototype.
+                ref: c6f0870c21e08d223cd1c358cdb0510a4e4716ae
+            bval:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3c46c8975f01e54b8019b0ea7fcae30414d4d8d1
+            byacc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 85ec7d4c63aa5cda1871b2a014beb74506e4a4f4
+            byaccj:
+                rationale: Part of the first base-runtime prototype.
+                ref: bbe09b2a02833a22a340d1c66f6c4a47c7c54910
+            bytelist:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2d5336c9f83917eee87ec7165f8fe50979533e83
+            byteman:
+                rationale: Part of the first base-runtime prototype.
+                ref: 67de8b29ba51b9543c89df9de7f6fd138d38a7e0
+            bzip2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4fd96003106886424cc0da9a6a7af0a6ba1d02c2
+            c3p0:
+                rationale: Part of the first base-runtime prototype.
+                ref: b364f3818fd1cac0b83a7a499c93ce9d72443533
+            ca-certificates:
+                rationale: Part of the first base-runtime prototype.
+                ref: 47df26b1b98519f8347ea0b0649d124b38775989
+            cairo:
+                rationale: Part of the first base-runtime prototype.
+                ref: 36e3e0b7730d483e7b2be1f840ba9fd46ab83341
+            cairomm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 715237d84ebea14b4c00400c573e274a22c9328a
+            cal10n:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7b1512f5fd9834ceadb7f655f2630f1f5206ad6e
+            Canna:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8d636177ba858cfabf02df029b2089cf192d683e
+            c-ares:
+                rationale: Part of the first base-runtime prototype.
+                ref: d76c7c5e9b096c4dc60643d41a5dc689068909fd
+            castor:
+                rationale: Part of the first base-runtime prototype.
+                ref: d69139022d2c80571dbef6e289cd552ed436f203
+            castor-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: ff92a88769a86a5fa028899b685af82cdd36277a
+            cbi-plugins:
+                rationale: Part of the first base-runtime prototype.
+                ref: 28ef5053eaa2cf74c045fb018241bd1ecd9808c6
+            cdi-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8dd12842234253373fb147e061ffe9c5504676e2
+            cdparanoia:
+                rationale: Part of the first base-runtime prototype.
+                ref: 93d6236472b592f5a41a04629dd36219d14c0d85
+            cdrkit:
+                rationale: Part of the first base-runtime prototype.
+                ref: adfbbef79f12f6a9d2c97df4172f213d1b289a3b
+            celt051:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7287854f333cec1dc930d4448c9a6b01c45e1494
+            ceph:
+                rationale: Part of the first base-runtime prototype.
+                ref: 50ab9b56e2f7939f30a5a3442135f0c297aff0bb
+            cfitsio:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5aa694dcd4e55f2ba75e735f239576cdaf0bf4b1
+            cflow:
+                rationale: Part of the first base-runtime prototype.
+                ref: b38c4535290570c2154e78a7437e14ad1e95c28b
+            cglib:
+                rationale: Part of the first base-runtime prototype.
+                ref: e6d3933886264bcfb0f233e0ce1acd661629fb72
+            check:
+                rationale: Part of the first base-runtime prototype.
+                ref: 421fa70ac585213deb394d1278f4c6d44ab9f9f8
+            checkpolicy:
+                rationale: Part of the first base-runtime prototype.
+                ref: d70b2042c66a4ccd17d9ae5c1bf78d474f20db30
+            checkstyle:
+                rationale: Part of the first base-runtime prototype.
+                ref: 77a88a2a278811b936790b5a6004e2f8f3ec27ed
+            chkconfig:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9fcce375bd102fdf36537786be4cb704af2f9dc1
+            chromaprint:
+                rationale: Part of the first base-runtime prototype.
+                ref: e1a53cbaa097a111841f6702020d9e5e75d09559
+            chrpath:
+                rationale: Part of the first base-runtime prototype.
+                ref: 10a327943900e9df399fc0074462102b2982150c
+            cifs-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5ba1ec252af770b50c71d8b3241d513fa26508dd
+            clang:
+                rationale: Part of the first base-runtime prototype.
+                ref: fd63610295bdb65ea3fd0abd100d6d3ebb7b847e
+            cloog:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3905e5260a07a692e97e4cc27f4e4254791bf4fc
+            classmate:
+                rationale: Part of the first base-runtime prototype.
+                ref: 07c97bc2697227857bfc90d844fcc63a37521653
+            cli-parser:
+                rationale: Part of the first base-runtime prototype.
+                ref: e614bdcf524bb1977ad04c9f77de1067cf2df50e
+            closure-compiler:
+                rationale: Part of the first base-runtime prototype.
+                ref: f08675d46b5d045c2409c40bad949f5d0e5b87c0
+            clucene09:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1071a5d504ead0f7d465e390f1aaa7b76db49f56
+            cmake:
+                rationale: Part of the first base-runtime prototype.
+                ref: 72da9d7a8deba22e58251d75a428b150a862fe86
+            cmdtest:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8c4fbc4b1f7308517ee6ae3586005930391cc70e
+            cmocka:
+                rationale: Part of the first base-runtime prototype.
+                ref: a9d58ba26e3d52104e3d2bea6d23ed0c9089afb9
+            codehaus-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: af2106e3731a09fddc7856af1c1b15bd1e29a4e3
+            codemodel:
+                rationale: Part of the first base-runtime prototype.
+                ref: 003eed53625ee79b3bed1e1cd58d7ab89fa28abf
+            codenarc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 928a91c0ad5ea49e2a7c452bdb7be948cd5e14da
+            coffee-script:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0aedcf1404ea8118bf7c52a2f4fee2fc05097390
+            colord:
+                rationale: Part of the first base-runtime prototype.
+                ref: b7b2787ef4a0edf76d473a7b02d515a8c67f0ccc
+            color-filesystem:
+                rationale: Part of the first base-runtime prototype.
+                ref: 10b1876f6e58acb2a15a1a223de12740e0ad6bd6
+            compat-guile18:
+                rationale: Part of the first base-runtime prototype.
+                ref: cf868eb55b97fba9793852fb7029061f516731f2
+            compface:
+                rationale: Part of the first base-runtime prototype.
+                ref: 165bab7e5cc6d64a2e823cf2f7d3ce72c17ee0d4
+            cookcc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 20dc89debe536779a11c62739a09e775b304a321
+            cookxml:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8e9a5b90b42fcadf9c66a51af431ca988fd20249
+            coolkey:
+                rationale: Part of the first base-runtime prototype.
+                ref: 62f0d3a23835ccde322ae1d4cb9391bea871f1ca
+            copy-jdk-configs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 68c6afbcd5272abc2f776295de3026a52080a371
+            coreutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 39f7c7c836d63c96a8c9148ddc9c21b567705f1f
+            coro-mock:
+                rationale: Part of the first base-runtime prototype.
+                ref: e359c2aaa7da9a9d069f739f41741c1060f655a7
+            corosync:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3360c3f91b9f8e7cce05e9b18a4524d2ce24e4de
+            cpio:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3a41aea17c42080577416feee266377c4389b0f4
+            cpptest:
+                rationale: Part of the first base-runtime prototype.
+                ref: d507618838fd9578970f0ee6227c3b2ccc16f34b
+            cppunit:
+                rationale: Part of the first base-runtime prototype.
+                ref: c0f9286546d7a76357966ad18a0373a2421ae747
+            cracklib:
+                rationale: Part of the first base-runtime prototype.
+                ref: aff542331c9e59e5973d0a91bb91946afff954df
+            crash:
+                rationale: Part of the first base-runtime prototype.
+                ref: 877f9912a52239ee56eb31078d5a4eb210d152ba
+            crda:
+                rationale: Part of the first base-runtime prototype.
+                ref: eee1c92ee00a1b54fd2faa14ca32617e5f1c8402
+            cronie:
+                rationale: Part of the first base-runtime prototype.
+                ref: a1d815b665229fe24511c8bada6a4e3ef6a9ba63
+            crontabs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5b42363b93e2811a209f21703bacc8fdc16b5a5e
+            cross-binutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 155210add834877b01b0589004d025a27a439959
+            cross-gcc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 859d2c95842e0485e3ce4c218bb2d837c740406f
+            crypto-policies:
+                rationale: Part of the first base-runtime prototype.
+                ref: 22cb5df2a46181c1f438c0789b21b7cd736ea340
+            cryptopp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0ea020fb472f41108d3073969c4cca5ab409121d
+            cryptsetup:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7fa49fb8b1770c9b723eaf57897069e955ea6366
+            cscope:
+                rationale: Part of the first base-runtime prototype.
+                ref: e483e822f7af107f921007e3697a7f77e928edb4
+            csnappy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 848cb65605cc8c8bb1c808530f3b1af5de34e689
+            ctags:
+                rationale: Part of the first base-runtime prototype.
+                ref: eab9e808feb0db74cb8598f90dcffa4092081046
+            CUnit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2fb6e8f0529a1196a4bd0897e9bfcd93719e686c
+            cups:
+                rationale: Part of the first base-runtime prototype.
+                ref: 523b1be22fcebb6624a4dab6bde7e4aedc9734cd
+            cups-filters:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3b8a7339c8b1fa456a8412197783b3ce2d2bc6c2
+            curl:
+                rationale: Part of the first base-runtime prototype.
+                ref: b552e5528dfb2a1e9d674250679e0cfe93292880
+            curvesapi:
+                rationale: Part of the first base-runtime prototype.
+                ref: b7417284fa4a8622a04f2c8d945bde872fa217a2
+            cyrus-sasl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1d717c4fec30c7d4be93e988f850a739dcfc6b3e
+            Cython:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4b5b3074b52b4c99d22d9e10947457f06c60f754
+            dain-snappy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 76ba95e46a49ffd6dc20f56d2e6a348926ba1e05
+            datefudge:
+                rationale: Part of the first base-runtime prototype.
+                ref: 627bfbf9c17596c718b48a02398cecd5cd705bb9
+            dblatex:
+                rationale: Part of the first base-runtime prototype.
+                ref: aa970d891602703162e2ea850e0de8e51efa9425
+            dbus:
+                rationale: Part of the first base-runtime prototype.
+                ref: 18c422a071f7486dbe34dd09651fe457d404fd11
+            dbus-c++:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5a0269e897a2ded0aeca97b20560e3ab12507a32
+            dbus-glib:
+                rationale: Part of the first base-runtime prototype.
+                ref: a574c59d4b33bfec55836f3e4b49b18a988cf430
+            dbusmenu-qt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3175519d058bda22ade60d7ab59902e86d23938d
+            dbus-python:
+                rationale: Part of the first base-runtime prototype.
+                ref: c275cda754d9d8040275b583a6885e034385560b
+            dconf:
+                rationale: Part of the first base-runtime prototype.
+                ref: e5a9128119331425f6f5587f756afd2bbcd7e5d5
+            decentxml:
+                rationale: Part of the first base-runtime prototype.
+                ref: ecf0896462f5c77f25054b60889f31f18114e977
+            dejagnu:
+                rationale: Part of the first base-runtime prototype.
+                ref: 810373f1bf08ef23a03e78d3cc3de5400c64794f
+            dejavu-fonts:
+                rationale: Part of the first base-runtime prototype.
+                ref: 87977d88ca3fdfc9610df01b09f99f5fbf3a5be2
+            deltarpm:
+                rationale: Part of the first base-runtime prototype.
+                ref: b87cfa671c80351aea95e6f135250b68ec97ae70
+            derby:
+                rationale: Part of the first base-runtime prototype.
+                ref: 258fc7ce37c0d39fe1484fafbbbbbd5ec190d8b8
+            desktop-file-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 52e7d4865a9bd767fc4ef02f8ffdc9462017da81
+            dev86:
+                rationale: Part of the first base-runtime prototype.
+                ref: 00c971a035398f9cce754f1ff07434e7b50f490e
+            device-mapper-multipath:
+                rationale: Part of the first base-runtime prototype.
+                ref: 906e1e11285fc41097fd89893227664addb00848
+            device-mapper-persistent-data:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9e7d28d253dac7842deece5c180d4c8564a40d89
+            DevIL:
+                rationale: Part of the first base-runtime prototype.
+                ref: de58614c0febb5032b710739f34f7344679668f6
+            dhcp:
+                rationale: Part of the first base-runtime prototype.
+                ref: f4e9ae9e62a8e9a19c77d98c196256b4075a99d9
+            dia:
+                rationale: Part of the first base-runtime prototype.
+                ref: fc42bb6ece50308d23e77e95c8fc199ac2b76434
+            diffstat:
+                rationale: Part of the first base-runtime prototype.
+                ref: 719f28012bb70071a8c325a6849003645a26afd3
+            diffutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: c7eed45830193c6df7cc63dd4a971ef323074e93
+            ding-libs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1681b78086ad76d009722b3134da815ce2800806
+            dirac:
+                rationale: Part of the first base-runtime prototype.
+                ref: bbe39f81ec4781fe6c09db693477cfd7d6489224
+            discount:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9370b129c801a8e7ef3ae06d5d56c23d98395506
+            disruptor:
+                rationale: Part of the first base-runtime prototype.
+                ref: 05fb7fddc25ef1b9a4a134b4d41c51456fb2058d
+            djvulibre:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2097e196fa060f1dfd266ed3526916d6e5787a4b
+            dlm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 482579474a2357fb8aec3350dd9100ff41e1b21f
+            dmraid:
+                rationale: Part of the first base-runtime prototype.
+                ref: 613e07d1a07ca253cee3c8ed567c8b029a67c6f6
+            dnf:
+                rationale: Part of the first base-runtime prototype.
+                ref: fa731a51dbc4305a3d82b095d967df382e2e87ad
+            dnsjava:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6f0ba3302a001e7e9f7a71ce2c2e037a5246ceb3
+            dnsmasq:
+                rationale: Part of the first base-runtime prototype.
+                ref: 30dfb6676861ac0ad0df4310ab95fafa6d658041
+            docbook5-schemas:
+                rationale: Part of the first base-runtime prototype.
+                ref: dcab52803cb5e16f21511db790ed44738bf2c5b1
+            docbook5-style-xsl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 23365309bd016c5cb627f84c0a5af461675b3bf4
+            docbook-dtds:
+                rationale: Part of the first base-runtime prototype.
+                ref: bfccce44dbb38964d3e43d9b1566f25d318637fa
+            docbook-style-dsssl:
+                rationale: Part of the first base-runtime prototype.
+                ref: c3780d0a4ed21cc6cf6e5ab0a0c7f3ccc34be28b
+            docbook-style-xsl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4066862e4ae7d0ef35aaac566f59317d494d7aa1
+            docbook-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0df97c006e77d71ac7e36f0b1d4255509b46ee2b
+            docker-client:
+                rationale: Part of the first base-runtime prototype.
+                ref: 61a559aa40c44e9ec852887d2e20ae00994a57c2
+            dom4j:
+                rationale: Part of the first base-runtime prototype.
+                ref: dddda19c66a858c2c0c6eb46aec69c4da20a6b71
+            dos2unix:
+                rationale: Part of the first base-runtime prototype.
+                ref: c6edc79eb9bc8ab8c3bf480601065cd1fddaedb4
+            dosfstools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 35480096c2fd311f0c0d00fe0a89c06afcef8847
+            dotconf:
+                rationale: Part of the first base-runtime prototype.
+                ref: c06d3f3901afa9f9ade7412c77bef780d1a7f1c8
+            doxygen:
+                rationale: Part of the first base-runtime prototype.
+                ref: dfc5f33cc2252c6f309a118903ea48b95da7d484
+            dracut:
+                rationale: Part of the first base-runtime prototype.
+                ref: 51c99792c08ec6f8c8208a7bc09d09d1b926f23f
+            dtc:
+                rationale: Part of the first base-runtime prototype.
+                ref: cda652e10385387e5091ac4c9713b6717b2427bd
+            dwz:
+                rationale: Part of the first base-runtime prototype.
+                ref: 89f53e8a038dad324017ad08f26dc8fdc76d8db3
+            dyninst:
+                rationale: Part of the first base-runtime prototype.
+                ref: eafaeab37f82d369ce9d3af83ee0a48f43e0aec5
+            e2fsprogs:
+                rationale: Part of the first base-runtime prototype.
+                ref: acca0241b0e46f4af2af6292d6013d4cfba7e5be
+            easymock:
+                rationale: Part of the first base-runtime prototype.
+                ref: 00c2c26bd2dddaef679853fefb4eb19fb24efdb1
+            ebtables:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2dc06bec77576a075ad36b26b86d92354076ff4e
+            ecj:
+                rationale: Part of the first base-runtime prototype.
+                ref: 246197667ee008320f46e5f9dda567ad12cc5d9b
+            eclipse:
+                rationale: Part of the first base-runtime prototype.
+                ref: 646e9715ea82abc263641efcbec21e4991ab5ecb
+            eclipse-cdt:
+                rationale: Part of the first base-runtime prototype.
+                ref: dc7bd64e4afd6c856884ad2e229d1b084744e598
+            eclipse-ecf:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4fc52d3a094a0ee979e50123483813b065f8e62f
+            eclipse-egit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 011a35407d8f60e427fdf0bf4e1d2a07e48a83d6
+            eclipse-emf:
+                rationale: Part of the first base-runtime prototype.
+                ref: 721615660ca958f1ce9d2edc8479bdbe62b85a21
+            eclipse-filesystem:
+                rationale: Part of the first base-runtime prototype.
+                ref: 249ebb08ba256862d48c29265331d32575024bfa
+            eclipse-gef:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6109a629420289fd8128ed26a9a1d8812d84d0d2
+            eclipse-jgit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 472b3f5ed07e7bb4aa855d3345199377c05dd796
+            eclipse-launchbar:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4d32ca19fdfc8a287f9dbc2963e4f6799b036a53
+            eclipse-license:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1b0586e48710a036152e4ff35da6227796bff80c
+            eclipselink:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2c48abf437ca43249dc39e794e0c0ab06271bc45
+            eclipselink-persistence-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 933ce52924d4cd70feb210665a95a0c29aaf3086
+            eclipse-linuxtools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 543517dab75a35547f8f2e5bd75faa04407e4af1
+            eclipse-mylyn:
+                rationale: Part of the first base-runtime prototype.
+                ref: f105a74971827b3984cc6ebd2f777e6dea4a135d
+            eclipse-photran:
+                rationale: Part of the first base-runtime prototype.
+                ref: e3c7a5c3433af8ce9b64f15c6453c2fd245bdada
+            eclipse-ptp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1ab178f618547e88e3d36b2e6cfe9e551725d4ef
+            eclipse-remote:
+                rationale: Part of the first base-runtime prototype.
+                ref: d3fbd019a22d23b7d919340589e494358446b33b
+            eclipse-rse:
+                rationale: Part of the first base-runtime prototype.
+                ref: d77dacee0ac91869a43c8e77040b122199253e0a
+            eclipse-subclipse:
+                rationale: Part of the first base-runtime prototype.
+                ref: c5dd6c92af01134a9cc34326f0a61e60852a2aa5
+            eclipse-swtbot:
+                rationale: Part of the first base-runtime prototype.
+                ref: f516095dc0d3b3772edc50e29e1e02aa79d793f4
+            eclipse-tm-terminal:
+                rationale: Part of the first base-runtime prototype.
+                ref: e84a3bffb5ded3ca84079562d85e0420183ef730
+            eclipse-xsd:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5a8b0f1d5d69f2763a78f0904b14bf47c73a835f
+            ed:
+                rationale: Part of the first base-runtime prototype.
+                ref: abc0235d4923930745ef05d873646f361a365457
+            edk2:
+                rationale: Part of the first base-runtime prototype.
+                ref: da615e40fa891c50749c95f1b1b11780702f43ff
+            efivar:
+                rationale: Part of the first base-runtime prototype.
+                ref: 45df8dc87466160244febb19d404782d6f59a839
+            efl:
+                rationale: Part of the first base-runtime prototype.
+                ref: b2b604d5bb86a76b65b064860a0276354a024fcf
+            ehcache-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5fc3a31df542703774b723f90ce496004119c51c
+            ehcache-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6cdf20d64a8410de7775f7bbd5d13ec925869b36
+            ehcache-sizeof-agent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2f6df3877a8b94d1c705084e343cee941836e285
+            elfutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: d3c2ef0ac88967069dfd1bc99f79417a8b17236e
+            elinks:
+                rationale: Part of the first base-runtime prototype.
+                ref: 904b9b13f2d06e21240aaba239b94146630b4102
+            emacs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 430d29bb0b180cbed04700294fb076c00081e51e
+            emma:
+                rationale: Part of the first base-runtime prototype.
+                ref: c44345955e25124305ca31b3bdaa3b7b62a8737e
+            enca:
+                rationale: Part of the first base-runtime prototype.
+                ref: b4e54df5cc9d8d287cf25553a0eb24ed3a2e6912
+            enchant:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3bd95c25d0d8845385738de49b88e06e418b5012
+            environment-modules:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6d5d9281e04f5dd3e9c7c5c8dfeabe505cb34091
+            epstool:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7c3f885c73ab32ee53877d568c69f08b06a79a04
+            epydoc:
+                rationale: Part of the first base-runtime prototype.
+                ref: df4b06193afabc3c353e1a15d4c1477547fc8126
+            erlang:
+                rationale: Part of the first base-runtime prototype.
+                ref: d02dbcf40ad1422e5d4300a37acd3b6d589b71da
+            erlang-eflame:
+                rationale: Part of the first base-runtime prototype.
+                ref: a9f93375d8552f988f3bb5161a88a9804baf2f96
+            erlang-erlydtl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 76d147c1dd4c1e4a7358d76afff643418d075271
+            erlang-getopt:
+                rationale: Part of the first base-runtime prototype.
+                ref: bae2e50c6adff52909163794c67f49c6575fffc2
+            erlang-gettext:
+                rationale: Part of the first base-runtime prototype.
+                ref: a72cbdea86d1c02fe3125ab3e7ac89e1e509db73
+            erlang-hamcrest:
+                rationale: Part of the first base-runtime prototype.
+                ref: b5d8ce5fe234190478efdf4c601b63b6dfc56bb5
+            erlang-lfe:
+                rationale: Part of the first base-runtime prototype.
+                ref: f18288f91efaa5d0f35402f3a1e67b41d5a421e3
+            erlang-meck:
+                rationale: Part of the first base-runtime prototype.
+                ref: 292bf487a9889380575435cda13a740c28a6764f
+            erlang-mustache:
+                rationale: Part of the first base-runtime prototype.
+                ref: a795543d79c25ff45ae17c289e71faa2a84cb202
+            erlang-neotoma:
+                rationale: Part of the first base-runtime prototype.
+                ref: f271b6215045cf07b1fa6758257523724355fc0c
+            erlang-proper:
+                rationale: Part of the first base-runtime prototype.
+                ref: 55c0ff563464437d478f3471b5df6fba4ad831aa
+            erlang-protobuffs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4d1c8f362909723a80420d9fa59e3069443c1824
+            erlang-rebar:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2b3f6c608cce56a932c0f73f38da7477526e6bac
+            erlang-rpm-macros:
+                rationale: Part of the first base-runtime prototype.
+                ref: dee569d7ded39e082ecdef157d80ae723f4e3883
+            erlang-sd_notify:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1f37740aa4721e6e7c0d8d2e1da03e7fa6a86573
+            esound:
+                rationale: Part of the first base-runtime prototype.
+                ref: f45d5230410ddbe2c49f400b43c17949bfb9c6e3
+            espeak:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2fb3cca7e02a3e5f1abbcd7af76e8d4762687660
+            exec-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: e47d6122da73e9c2e91da0384815e008aed6dc18
+            execstack:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8e460387fa1af170f2a58dc1db282b75d690070c
+            exempi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94d89790bae9b2921296615b68d7435e8f8bc447
+            expat:
+                rationale: Part of the first base-runtime prototype.
+                ref: ac9d5d4febcf60ec65b17054dbe90386949f59d0
+            expect:
+                rationale: Part of the first base-runtime prototype.
+                ref: 45f36777682cb375ac6a2cab236c50f093d6438a
+            expresso:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0ff3a0050aa3076dd1afc1d5356b954dfd52af2f
+            extra166y:
+                rationale: Part of the first base-runtime prototype.
+                ref: 58503665dc8be9ab812e2dcefd81cab9fdf379c0
+            extra-cmake-modules:
+                rationale: Part of the first base-runtime prototype.
+                ref: 809bca05475845bb16bd2135800479dad32f80b6
+            fakeroot:
+                rationale: Part of the first base-runtime prototype.
+                ref: de55f4d8d9d17bfdd3332172a34e905c12d3545a
+            fasterxml-oss-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 85565422e675cf47ba842bc685957296cff06d6b
+            fastutil:
+                rationale: Part of the first base-runtime prototype.
+                ref: 14f2116b26590200ba0ea3516bb67f983161caca
+            fcgi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 21d88676a6987f09725314f7ce2ac1a438c9ff0f
+            fedfs-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4fc135d856da6192543ea8ea7ad61ec4d4cc4dad
+            fedora-logos:
+                rationale: Part of the first base-runtime prototype.
+                ref: 85de6b7053eab9e443b5ddcc4ae31ba087a2e85a
+            fedora-release:
+                rationale: Part of the first base-runtime prototype.
+                ref: ee51091e24e4bcf5073b42f6736214187f6bbc82
+            fedora-repos:
+                rationale: Part of the first base-runtime prototype.
+                ref: b0e1e2dc384157c51d9a9c8f7cba34eb255b4134
+            fedpkg-minimal:
+                rationale: Part of the first base-runtime prototype.
+                ref: e54be74e0c22162e4fb4b11cef1f370d47b6ab4f
+            felix-bundlerepository:
+                rationale: Part of the first base-runtime prototype.
+                ref: 25909c52e75be0e9d8d53f1f7da60a5e5d9c4b78
+            felix-framework:
+                rationale: Part of the first base-runtime prototype.
+                ref: 880bded6dffa7719298ca2f9df8ba26fdce81ce7
+            felix-gogo-command:
+                rationale: Part of the first base-runtime prototype.
+                ref: 03ecf17a1df1ecab82cd83175c068576ac06d412
+            felix-gogo-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8379e97bebc8138b6256052c2f4258cbbf7c417b
+            felix-gogo-runtime:
+                rationale: Part of the first base-runtime prototype.
+                ref: b65c67c5205aa4c6a10d9aa7565c485424a8cef1
+            felix-gogo-shell:
+                rationale: Part of the first base-runtime prototype.
+                ref: f650917340f194fabd83c14987b031906f6b1369
+            felix-main:
+                rationale: Part of the first base-runtime prototype.
+                ref: c0207a03120d2302d05c2b20aa272b36d27b7aeb
+            felix-osgi-compendium:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0f2470e7bf97a62a60cfcb77ee186b1953b742ce
+            felix-osgi-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5b21e10f03694bf74b968db56dc36e70584907ef
+            felix-osgi-foundation:
+                rationale: Part of the first base-runtime prototype.
+                ref: cb284a5130d0fa73886618b0b4ce52f9a4db8950
+            felix-osgi-obr:
+                rationale: Part of the first base-runtime prototype.
+                ref: 729fc1faf45b4d78eda3cec805b4f469e55d3229
+            felix-osgi-obr-resolver:
+                rationale: Part of the first base-runtime prototype.
+                ref: e7a7a8856840a25291bd28f4f98a99a3f2d28f71
+            felix-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 800a5723778804c7a316314dcacdd93ee218dfc1
+            felix-scr-annotations:
+                rationale: Part of the first base-runtime prototype.
+                ref: 748a55faa05da23f99a786687e4bf32ca69ccdf6
+            felix-scr-generator:
+                rationale: Part of the first base-runtime prototype.
+                ref: 87ae547e7b5e9ce7fd8ece0719018d9566d698ad
+            felix-shell:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4ecffad7e151a0508b7d8f7e9f44e4f56fc87279
+            felix-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 47ef7f780ad90c9291377a86bf9974bc67dfa93e
+            fftw:
+                rationale: Part of the first base-runtime prototype.
+                ref: e268a167984dc9eaabae75977023ffefa2f40954
+            file:
+                rationale: Part of the first base-runtime prototype.
+                ref: c3d464c025f037affcd92769d19411ce47420403
+            filesystem:
+                rationale: Part of the first base-runtime prototype.
+                ref: dd13bc443945d67c28625f0c734abe34d8e148ed
+            findbugs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 52c4d98450b9a50ec3d4e693e35f9bfe318f749f
+            findbugs-bcel:
+                rationale: Part of the first base-runtime prototype.
+                ref: 80b50bf801488a3bac5a61b3d20ad6e60f62cde4
+            findutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 662a63d728ca213419d454088546a5fa5b69e6c5
+            fipscheck:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1e1a23259e60b221d7bd05c562def006f390c932
+            firebird:
+                rationale: Part of the first base-runtime prototype.
+                ref: 208b506475433ebb94e6b678d926bca7a3b58888
+            firewalld:
+                rationale: Part of the first base-runtime prototype.
+                ref: f382652417b11eafcd84560c8a52a0288449b810
+            flac:
+                rationale: Part of the first base-runtime prototype.
+                ref: ea4db547eda83b5d29086ef57c9083437418c735
+            flex:
+                rationale: Part of the first base-runtime prototype.
+                ref: 489034354ea8bf34e4dbde6b2680f1cb54f1cbcd
+            flite:
+                rationale: Part of the first base-runtime prototype.
+                ref: d06db0c4ed2d5c716bbaeede486aea12dbf50034
+            fltk:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4beb94e56dc316180321a8d8e9786a8e37502053
+            fluid-soundfont:
+                rationale: Part of the first base-runtime prototype.
+                ref: 524b5287729a6eafe5976d65205261aff00bb45b
+            fluidsynth:
+                rationale: Part of the first base-runtime prototype.
+                ref: f6ccfbf2f6c96b52c30a8745b062a95a140155c3
+            fmpp:
+                rationale: Part of the first base-runtime prototype.
+                ref: b98a6c363eaa73a4b2d41272f90dbdfe50936ecc
+            fontawesome-fonts:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9622635c427a524841fd628d1c48cf045a623202
+            fontconfig:
+                rationale: Part of the first base-runtime prototype.
+                ref: bb21e1aefa8afde0bf44a6e52e28162a4065efa6
+            fontforge:
+                rationale: Part of the first base-runtime prototype.
+                ref: 47e862ad38e8b335175c5bc5ca9c9d3da8e05375
+            fontpackages:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8f3ea2913a663cfe0888c0ee24708b567d3f011d
+            fonttools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 974a1e19686dd8084460b956bb0471066371e00c
+            fop:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0c23b90d6e269254ca56b9577ae47e0e4aa96c00
+            forge-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: bb6c1786c6a063e5e79be4ea874b0bb184fc0d8e
+            fpc-srpm-macros:
+                rationale: Part of the first base-runtime prototype.
+                ref: b7917d5694359a5f458d0c620bec64bd97949d89
+            freeglut:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8846528c50abe7524e30a18a037a98b5aaa02811
+            freemarker:
+                rationale: Part of the first base-runtime prototype.
+                ref: 10c3da5da279c6a2c67e186f68f0d4b000e1e63b
+            freetds:
+                rationale: Part of the first base-runtime prototype.
+                ref: e77811b9ddd9ac63840f4acfcd739ef549c79108
+            freetype:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9a81147af83b1166a5f301e379f85927cc610990
+            freexl:
+                rationale: Part of the first base-runtime prototype.
+                ref: f539bca69d75553208039b348e0970cf3500b207
+            fribidi:
+                rationale: Part of the first base-runtime prototype.
+                ref: f0ef3128fb326e6c80261f6b0d8ba485566420e4
+            ftgl:
+                rationale: Part of the first base-runtime prototype.
+                ref: ce07a491b213b917d3ab2212196afd05a6bd3317
+            fuse:
+                rationale: Part of the first base-runtime prototype.
+                ref: ca34919dce50d04c3458ffe855153d2aca7c077c
+            fusesource-pom:
+                rationale: Part of the first base-runtime prototype.
+                ref: e0dadc275283d97dafa3b5cbaf74230ff16427d6
+            g2clib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 19e5ea27d08fdd0250aabc696e95e308c2c32750
+            game-music-emu:
+                rationale: Part of the first base-runtime prototype.
+                ref: a3400fac96653d7a4e94df3d218ce37fca170111
+            gamin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5e8297c2796435259908be1836f380d00d67a89a
+            gawk:
+                rationale: Part of the first base-runtime prototype.
+                ref: 08bec36937dd9b219b1da9a92ae6ecd16c4ad3be
+            gcab:
+                rationale: Part of the first base-runtime prototype.
+                ref: 378eafd083e1fc8f8ecb2563e630f2a273026841
+            gcc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 71feea0f83dffc86f285e1195206e6de35c682c9
+            gc:
+                rationale: Part of the first base-runtime prototype.
+                ref: c74e94dd85f7591cab4bfd6f48bfef6a26ebb495
+            GConf2:
+                rationale: Part of the first base-runtime prototype.
+                ref: a13087720a27b17b61bd0a1cbd6042a1d0ab98b7
+            gcr:
+                rationale: Part of the first base-runtime prototype.
+                ref: 86fd1d0e8ba7b70f4798a90016e904f2a7b7184d
+            gd:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5504d4e60b3a25d1b77b8b73b19021d3c63aa42f
+            gdal:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9f6a4ae2b1c62b58c9acb951570a5e859c4827f4
+            gdb:
+                rationale: Part of the first base-runtime prototype.
+                ref: d08a20f70d532f4e9a41f33aee3ce334063a69fe
+            gdbm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 28ca9ebe71520f7c3ea7c71297f484f9dedeeddb
+            gdisk:
+                rationale: Part of the first base-runtime prototype.
+                ref: ada9474640b0e2da828604dbd48204701ddde994
+            gdk-pixbuf2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3c435a9586229219d6d26ed55b48ef1640c40537
+            geoclue2:
+                rationale: Part of the first base-runtime prototype.
+                ref: d328903349d49ac6312192bc33f4ccc6316b3a7e
+            GeoIP:
+                rationale: Part of the first base-runtime prototype.
+                ref: fcf153ae621b2b97da8beec55835128246ecb63a
+            GeoIP-GeoLite-data:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5227b708aac7c331a5701054d43dece3900dbfdf
+            geos:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6074c5198e63e1b621686e87e4c8c3120a5caf51
+            geronimo-annotation:
+                rationale: Part of the first base-runtime prototype.
+                ref: fa42df6a795b90abb46f14dad2eef8ea779988f8
+            geronimo-commonj:
+                rationale: Part of the first base-runtime prototype.
+                ref: 41006335b3aaf822756fcc4152f15f8e26b30bc3
+            geronimo-ejb:
+                rationale: Part of the first base-runtime prototype.
+                ref: 88bc2a20b98aaf8b2e7916b4ee0c46243981f119
+            geronimo-interceptor:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0e47dce6509b047fbf216f7c8faaf58f414e5213
+            geronimo-jaspic-spec:
+                rationale: Part of the first base-runtime prototype.
+                ref: 71a0772ee55eba84a5ab9a0e094e2642b6730aa6
+            geronimo-jaxrpc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1feefc45d4f8474b65f43845d7613ff6b1449a79
+            geronimo-jcache:
+                rationale: Part of the first base-runtime prototype.
+                ref: 582687c09db3185052c8c696e919d047a543620d
+            geronimo-jcdi-1.0-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 80c31926231356ddb4c51b0b6213bf7816b312ad
+            geronimo-jms:
+                rationale: Part of the first base-runtime prototype.
+                ref: e41da68f7464a7baebc61b609bd7688b55c12dbb
+            geronimo-jpa:
+                rationale: Part of the first base-runtime prototype.
+                ref: 21f642f60511f6e1d0fbcc4f4757ab443ef64ac5
+            geronimo-jta:
+                rationale: Part of the first base-runtime prototype.
+                ref: 53906f2d25ac965cea70a84fe61b6da42921a423
+            geronimo-osgi-support:
+                rationale: Part of the first base-runtime prototype.
+                ref: c7d199a4a89eb7413ede9f2f803e7cc1e5153a01
+            geronimo-parent-poms:
+                rationale: Part of the first base-runtime prototype.
+                ref: e66ecc19faf1f72ed74b2abb64d8cae0b96a5dc3
+            geronimo-saaj:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7d0286eb7ae0a50600aa6abd23e9fae6a7a4b250
+            geronimo-validation:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8c26a91b7a45f0ff06b00f8fe5d6520e251f0d4b
+            gettext:
+                rationale: Part of the first base-runtime prototype.
+                ref: 36a68602a180ec6c9a583e331c773d915abcf5ee
+            gflags:
+                rationale: Part of the first base-runtime prototype.
+                ref: 36f56f53eaf00ba6652c43b81b1fcbc2eba5a363
+            ghc-srpm-macros:
+                rationale: Part of the first base-runtime prototype.
+                ref: 254a5ce5dec521790dbfa342c560f93456882a80
+            ghostscript:
+                rationale: Part of the first base-runtime prototype.
+                ref: 040b22b22c7cbf1c02b551fbed49a5bfd76ceda5
+            ghostscript-fonts:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5bb57ea2ca1b9a6705d252d79b83c8fc774e7ce3
+            giflib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 23d3c726c385c0e2c79e0efad20818a168f1deac
+            git:
+                rationale: Part of the first base-runtime prototype.
+                ref: 24278ab333f8452ffd9c31cf8d917b61543393e0
+            gl2ps:
+                rationale: Part of the first base-runtime prototype.
+                ref: bdb4bcf0112392c5904ac0d88630443f381bca44
+            glassfish-annotation-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 62c47e224b463e139961db561595feb19a1920ae
+            glassfish-dtd-parser:
+                rationale: Part of the first base-runtime prototype.
+                ref: b68278523edc705bd640588011a36cb21e5fcd81
+            glassfish-ejb-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: aecd88a22d6ef691cc8d9672ee4d17ef839878d2
+            glassfish-el:
+                rationale: Part of the first base-runtime prototype.
+                ref: d50e1f7ecf0518ec6966ca9cfad859f86d1c1687
+            glassfish-fastinfoset:
+                rationale: Part of the first base-runtime prototype.
+                ref: fd87821f0fbea92d69575f0c2928d2ed9872c244
+            glassfish-gmbal:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5bd913727711576f7953d046b1c43701c66986dc
+            glassfish-hk2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 791753117d6c52a351c7621e02a7766b347e2f55
+            glassfish-jaxb-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: d9346c5bdc51865a04ac7da89066ffc6b1acf21e
+            glassfish-jaxb:
+                rationale: Part of the first base-runtime prototype.
+                ref: f5a152f07e6397aa3c024e30c1741e90e669fad2
+            glassfish-jaxrpc-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 111092953f3abf6236c50dd7b64707ded33a5b8c
+            glassfish-jax-rs-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 01eb1b72e9e42966621d3afc1226f1ec06b21672
+            glassfish-jsp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 03344f851ca43427468ad5a982ba2e8ea9fe4b24
+            glassfish-jsp-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: d309f72e1739ad26bfd6bd255085fe5e176239de
+            glassfish-legal:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4ed1bf3061af78b4f798c1e1950583f5517b5900
+            glassfish-management-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 648e62b38480e3b7272e4d89a8c3e6c18078a588
+            glassfish-master-pom:
+                rationale: Part of the first base-runtime prototype.
+                ref: d10fcc56dfb590e023b4c122a4c99d09653125b7
+            glassfish-pfl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 98697aefbe52854476cdb7f944f384927b91d764
+            glassfish-servlet-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9fae4f910dc42b8b1224c0671671f62f1a9c2ec5
+            glassfish-toplink-essentials:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1b9971468c4606861fa09e6b2e0849e9abb1f098
+            glassfish-transaction-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: ca111fb1a29814a70a5cbc314440115ff1137849
+            glew:
+                rationale: Part of the first base-runtime prototype.
+                ref: c9aeaca57a918400877e8e2da34bc7bc9c6d1752
+            glib2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 590ba0a7c2225ce3c76e683590f3d9c0f54b8429
+            glib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 60e8c13cf76c6d87b3b8bacf0e43eae980b8e601
+            glibc:
+                # TODO: Should probably mark this as multilib
+                rationale: Part of the first base-runtime prototype.
+                ref: 0a4bf015501d41208741c1b8a20d545d28894bb8
+            glibc32:
+                rationale: Part of the first base-runtime prototype and a multilib build hack.
+                ref: 0d1466d189c39fa7bfeb1ece173582ceae158eef
+            glibmm24:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7c6fd9c53e28f6a32fb3cdd43ad052965f9d74c6
+            glib-networking:
+                rationale: Part of the first base-runtime prototype.
+                ref: b1928e64f1a5be6eed0d2fee851dce02536fe43a
+            gl-manpages:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8efe558d2d7a42ba0e52d2fe01bf08d0a046d436
+            glog:
+                rationale: Part of the first base-runtime prototype.
+                ref: bf965e31d6ad564a637ccf2aa27ace396ef5d1fb
+            glpk:
+                rationale: Part of the first base-runtime prototype.
+                ref: eb8181a454321182d5b254f276eb4eeb450b54b7
+            glusterfs:
+                rationale: Part of the first base-runtime prototype.
+                ref: fd900b37707f0b9c56df498ee37301ff74e3258a
+            gmavenplus-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3428e59350476b1324678ead08181803cd76ec77
+            gmetric4j:
+                rationale: Part of the first base-runtime prototype.
+                ref: 392e29e28bffbb16899c39defe88dc09bbc8b3a1
+            gmetrics:
+                rationale: Part of the first base-runtime prototype.
+                ref: 832dc3b55ed601e7a69b88677d3505971311a0b2
+            gmp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2b2ac31a84863bc0d3f40a2b37c444eafb8278e2
+            gnat-srpm-macros:
+                rationale: Part of the first base-runtime prototype.
+                ref: 62a8800ff49cc5e40f7c67758c831fc570cc604d
+            gnome-common:
+                rationale: Part of the first base-runtime prototype.
+                ref: 45b93ab5df4ee8198f6f823ba4566342b40eeb26
+            gnome-doc-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 831ef65a02168155c6ceee6e7a2db9692c562f3a
+            gnome-online-accounts:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5f82d5451865f8173be8602963cefdeaf747a3fe
+            gnome-vfs2:
+                rationale: Part of the first base-runtime prototype.
+                ref: ccdb6c6dc8a94846ee3ed040ce23b92cb458cd0a
+            gnu-efi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1b3f3620eae682eb42815b1fc565b24f403b31be
+            gnu-getopt:
+                rationale: Part of the first base-runtime prototype.
+                ref: b1baad0c7e355a27bb9cbd39b4a1c924002682f9
+            gnulib:
+                rationale: Part of the first base-runtime prototype.
+                ref: d6ffc50bf31408f6e45351d1810615a6d03e1394
+            gnupg2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 347d5c8ca299a34d9b0d2fd179eb368c9ff0feeb
+            gnupg:
+                rationale: Part of the first base-runtime prototype.
+                ref: e29df2b4dd81a85469636946c7e46cf9041de5ce
+            gnuplot:
+                rationale: Part of the first base-runtime prototype.
+                ref: 89b9d5f3f30b16afe0f7d2fc47239e15af740bd1
+            gnutls:
+                rationale: Part of the first base-runtime prototype.
+                ref: f9a05a6fe911614833c62a46b2e9c8c0fd0cc6d6
+            gobject-introspection:
+                rationale: Part of the first base-runtime prototype.
+                ref: ef36c13ef2475593abb0bce6ad9679440f25408f
+            golang:
+                rationale: Part of the first base-runtime prototype.
+                ref: 663103c2f11d6ca9ef76cadcbd1950c6ab6e0dc8
+            google-gson:
+                rationale: Part of the first base-runtime prototype.
+                ref: 565d473dd5b63b564720b9d8cdafabac554ee4e5
+            google-guice:
+                rationale: Part of the first base-runtime prototype.
+                ref: 778052b7d6cee0b8b715052a7a22ecfb6dc9386a
+            go-srpm-macros:
+                rationale: Part of the first base-runtime prototype.
+                ref: c5278b88082e1c5661b29d90154c41975054c7bd
+            gpars:
+                rationale: Part of the first base-runtime prototype.
+                ref: b4aec25a3b3e33e746c7fd7126a06ddd3bc27b66
+            gperf:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6871fe8f6ca46b1ba86814fb6c5be936cc9d1a89
+            gperftools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 37c8cddcb5a0a3fde4f3df5cf86bf34145badd04
+            gpgme:
+                rationale: Part of the first base-runtime prototype.
+                ref: aef19f0b79a193aaf69a146aa267e0657d72f21e
+            gpm:
+                rationale: Part of the first base-runtime prototype.
+                ref: d470891740390defc9fd86f3c8e249a7026ad2e4
+            gradle:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9f26d0507c333916558b1e3e0d73405a2a255eaa
+            grantlee:
+                rationale: Part of the first base-runtime prototype.
+                ref: c9b938ad510448413bd3deb804654a8205f6636f
+            GraphicsMagick:
+                rationale: Part of the first base-runtime prototype.
+                ref: 14e33a31c10ddf6e0a71659c735601bd0ee4a62d
+            graphite2:
+                rationale: Part of the first base-runtime prototype.
+                ref: b745eebbe233afef4e0acf911066ac9d174c3bca
+            graphviz:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0dc2fdba000a3587b8ab8d2cc6f0ea645da6f0b5
+            grep:
+                rationale: Part of the first base-runtime prototype.
+                ref: 98c2bb4a4e1fe9dae810e72e144fb9fcc4e04d74
+            grizzly:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1487bdafc716dcc52c571e8b1c5b82165832e5bc
+            grizzly-npn:
+                rationale: Part of the first base-runtime prototype.
+                ref: f76fba5d325e4ffb73dc24055c95bbd10b0fbe08
+            groff:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8445f2a5f8adaf773f342271fe9e29eab2ccf9b4
+            groovy18:
+                rationale: Part of the first base-runtime prototype.
+                ref: cc64a78eeab984b9276debd0ba6b0b097bcf41f5
+            groovy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9885ee6c65d519fe4a5f6ea2bf52e9a99da6433f
+            grub2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9a4054fb1c5af194030d44f4e0a2c008afb0323e
+            grubby:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9e56840728f23e501991de2811cab78e2b72d387
+            gsettings-desktop-schemas:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8c684aa69954d23fe6e23d6429a83f18ce17b513
+            gsl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 263427c14514444a692715007429bd6dc9bc8eaa
+            gsm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 09329918fd45638cfea18f906d60918d8ccf75ec
+            gssproxy:
+                rationale: Part of the first base-runtime prototype.
+                ref: d59e9cc267d764482ca35b40068c86a44ceb9cef
+            gstreamer1:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2eb579950e0ed4e5bf8d0119c19fe0d9e57e7819
+            gstreamer1-plugins-bad-free:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5f295d3bc2f744a69e962c407b91506d40a9b69a
+            gstreamer1-plugins-base:
+                rationale: Part of the first base-runtime prototype.
+                ref: 01aab2b0e0ab0f8364222b5cd58df6929dd51986
+            gstreamer1-plugins-good:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7df77d72de0805f78a0c80a5a04b9bf91912f213
+            gstreamer:
+                rationale: Part of the first base-runtime prototype.
+                ref: 56d414531a8a7140ccc979aac34b8d298a2a16d2
+            gstreamer-plugins-bad-free:
+                rationale: Part of the first base-runtime prototype.
+                ref: 16fa09d95f8f2f3f31bb5414f19b6fcb4f21d9d0
+            gstreamer-plugins-base:
+                rationale: Part of the first base-runtime prototype.
+                ref: 16e16b484f510e6fbabd20dcae49441f53dd44d0
+            gt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 66077c73b7c959ec68d8ff2d0fcaf6eeb5c07489
+            gtest:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7d1f648a2e2a68aa9e526cca13d617706e142e12
+            gtk2:
+                rationale: Part of the first base-runtime prototype.
+                ref: ac19990e244acbf5fbe84e0fce5eeb90c00cdd51
+            gtk3:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3119f07477ef93bef9e4e60c073ffb08ccc77543
+            gtk+:
+                rationale: Part of the first base-runtime prototype.
+                ref: d7c3044596c42b4081e89e89d171ca0e3f1f4f0b
+            gtk-doc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2e16355b6ba69bf310d00e4c05d1610da0fa86c9
+            gtkglext:
+                rationale: Part of the first base-runtime prototype.
+                ref: 945cb2d7098dd9d53450937a4adf7c4760f5d112
+            gtkmm24:
+                rationale: Part of the first base-runtime prototype.
+                ref: 16c62210089508a987b326b7c4da72c3f379922d
+            gtk-sharp2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 64a134cea2bbf19b705feaf95f6de6e9963b33dd
+            gtkspell:
+                rationale: Part of the first base-runtime prototype.
+                ref: 360ebae138897c6191fc19dd698ad58883c274b9
+            gts:
+                rationale: Part of the first base-runtime prototype.
+                ref: a5b41f1b1b92dcdede89c63bee258633f7bb2d91
+            guava:
+                rationale: Part of the first base-runtime prototype.
+                ref: 178e48b116cefae6eb9973a512a86193a3dd79a4
+            guile:
+                rationale: Part of the first base-runtime prototype.
+                ref: d6c293425f5ea1d07a1b0bb734047009e023a000
+            gvfs:
+                rationale: Part of the first base-runtime prototype.
+                ref: ff9127df2dd28be1fd8df1043f88b4482fa461a0
+            gyp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8fc86db574c88888a8cb4f1fce6a1552361813fb
+            gzip:
+                rationale: Part of the first base-runtime prototype.
+                ref: 065fe88b598bf56686a9c573faa26618ab73fc08
+            h2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2bf33747f2ef745dcb976344426c12597db7bbc4
+            hamcrest:
+                rationale: Part of the first base-runtime prototype.
+                ref: 37eeb783c0c18fff58ada80194d00a5d066f2a0f
+            hardlink:
+                rationale: Part of the first base-runtime prototype.
+                ref: d669f21ef46cf8d8983f66fa8287aeff77b8d74c
+            harfbuzz:
+                rationale: Part of the first base-runtime prototype.
+                ref: a6d05d944cc1d8864c46cd076430b63de934a44f
+            hawkey:
+                rationale: Part of the first base-runtime prototype.
+                ref: 25239ff84034aa38e672b0aa82c8d88332e7edd5
+            hawtbuf:
+                rationale: Part of the first base-runtime prototype.
+                ref: d16f677491244c78b21fa499063e9cd60b6f86da
+            hawtdispatch:
+                rationale: Part of the first base-runtime prototype.
+                ref: 85afbdd416bd20e339d1aafdec88f5439b9802b1
+            hawtjni:
+                rationale: Part of the first base-runtime prototype.
+                ref: c11a23518ac824be7f4715d44217facfd44c891a
+            hdf5:
+                rationale: Part of the first base-runtime prototype.
+                ref: a22f315f429544756ec661449e80b0bd61423719
+            hdf:
+                rationale: Part of the first base-runtime prototype.
+                ref: 76238697af2a792527db03a5d0e5b158a15086ae
+            hdparm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9feb1990fa836972bcdec251a52f315fee246897
+            help2man:
+                rationale: Part of the first base-runtime prototype.
+                ref: 10d1c5c9749e64133d8a484fe27dc061f35cebb4
+            herqq:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9ebd75aa163db49f6988abf448552548be9f6407
+            hesiod:
+                rationale: Part of the first base-runtime prototype.
+                ref: fa1ec14824eedd88b6570a58777b4b37fe525af4
+            hessian:
+                rationale: Part of the first base-runtime prototype.
+                ref: bb693d8c8a47747ab6e82fbb8ed5f4e1affe26d2
+            hibernate:
+                rationale: Part of the first base-runtime prototype.
+                ref: 326fa240aa4a5fbd03917a34036eb7aed8d12e26
+            hibernate3:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5d32cf2268c208bcfc496b9645c72c287d40fe32
+            hibernate4:
+                rationale: Part of the first base-runtime prototype.
+                ref: afbf66d4bcd6d4b2b6d3fc23d5b8bf8ed4c148a2
+            hibernate-commons-annotations:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3042aee4f2788f5ccf057ac1e1271080aecc14f4
+            hibernate-jpa-2.0-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: ae597be3b1c3ce0eb55b8b64e77be43928b1ca04
+            hibernate-jpa-2.1-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1226bda5ab896cfc72dab2b8824cb38f42400b6e
+            hibernate-validator:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1d4fbcd2a2d5f0f76c753c0d026293b25a77ca7f
+            hicolor-icon-theme:
+                rationale: Part of the first base-runtime prototype.
+                ref: 342afca18674b38f7973b93d597962650ee1d408
+            HikariCP:
+                rationale: Part of the first base-runtime prototype.
+                ref: e7ca1b4cca03442b1d8a6f9de7cde6a2a518b84f
+            hiredis:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1eecb50aeaaec85f274eb50a3864504799741ed4
+            hmaccalc:
+                rationale: Part of the first base-runtime prototype.
+                ref: b589c84c749558c7251238fb93278b076974bd61
+            hostname:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4853019549ddbe7d97df2d1164ce493ab71167c3
+            hppc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 629837310dbfd26cb495a739363d5ce708d75b9b
+            hsqldb:
+                rationale: Part of the first base-runtime prototype.
+                ref: 01491e25e0c6e76612b242681596482be4c19bea
+            hsqldb1:
+                rationale: Part of the first base-runtime prototype.
+                ref: 32d91da1b085b675ee0fbbb3dd80dc320cd89bf2
+            html2ps:
+                rationale: Part of the first base-runtime prototype.
+                ref: d91553074981841f4d9b31d3ebd25426e0a6b248
+            httpcomponents-asyncclient:
+                rationale: Part of the first base-runtime prototype.
+                ref: 101c562057bf725d9b345e81c2d624bf4071bf1b
+            httpcomponents-client:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3be5d8572a95364ca020520fa20771b3abca82cf
+            httpcomponents-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7810c6cd4e0205ccb42d448c608a51224392ac33
+            httpcomponents-project:
+                rationale: Part of the first base-runtime prototype.
+                ref: adbe4b886929414dbce0132d78e5e007527a6e5c
+            httpd:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4a0435cd7b98675e67c387eb9cd5170112c6b494
+            http-parser:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5b87ba4c830faea0351534051191ba27b3b33520
+            httpunit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 88631656adf785505f7568767dc1b5f1c134b6e8
+            hunspell:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0240ac6e07879b92f04cb9b93aecc3200fe122ad
+            hunspell-en:
+                rationale: Part of the first base-runtime prototype.
+                ref: bbb47045866f00c2642af394d4b77b620e388bc0
+            hwdata:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1a0416fb1fdf8181d06d59d189727509b40ddec2
+            hwloc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6931416a49c50bd73fc4e6257b7d7b70dbf3ec56
+            hyphen:
+                rationale: Part of the first base-runtime prototype.
+                ref: 27b7fe86102003f0bcd6b7764bc3b70e0d8138a8
+            ibus:
+                rationale: Part of the first base-runtime prototype.
+                ref: bea250b789d0bcde0a710d3cf355365201010910
+            icu4j:
+                rationale: Part of the first base-runtime prototype.
+                ref: defe1d80fb04324e42c07bbc2de245b1659d5863
+            icu:
+                rationale: Part of the first base-runtime prototype.
+                ref: cc9ec210361a628028a1395752bac777dc929f6c
+            idlj-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 137fb65e04c637564c5daec78da5100860813a87
+            ilmbase:
+                rationale: Part of the first base-runtime prototype.
+                ref: 28dcf0bc2f2253c0df82fbe149a733926b740e3d
+            ima-evm-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: a10123346c3581a2b9f392fbdfc7b22f44006d5f
+            ImageMagick:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5b596715da86d3a2578fd309ba53adc6c6163f40
+            imake:
+                rationale: Part of the first base-runtime prototype.
+                ref: 93026baea5bf8d840c306a346101e35e340f8dad
+            indent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1a3c5b0a87b9041c5ebb139e472a7cf533ca1b76
+            infinipath-psm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6534b2cb7b8d513a1c0e95c8ea13b925bf279f76
+            infinispan:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1895c025043b67a3cddfb5844a03466eadfaa647
+            initscripts:
+                rationale: Part of the first base-runtime prototype.
+                ref: 37ba55c6e660cf787f0670350c64204e7bb854d3
+            inkscape:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5a24ab7e25076fccc811aa541d515e96874f9df7
+            intltool:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6c129f09a92cbfed0d449cfb30882ed7cad0aa9b
+            invokebinder:
+                rationale: Part of the first base-runtime prototype.
+                ref: d8f05f05cb0b2cf3a35a01027d33a26bd02f3d19
+            ipcalc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 29e7841afa11eaa2982151fb3a8ae48ca0f5253c
+            iproute:
+                rationale: Part of the first base-runtime prototype.
+                ref: 42ecebe23ab1479347eacf73c64e546f8ce94d90
+            ipset:
+                rationale: Part of the first base-runtime prototype.
+                ref: d6f6d5459b5df9ef74d665d8827895220ce99410
+            iptables:
+                rationale: Part of the first base-runtime prototype.
+                ref: 803e775de09a6e01977d23abcefe86c75f757059
+            iputils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 823348da5567018fef4dfd9b1aee517f1bba06d0
+            ipxe:
+                rationale: Part of the first base-runtime prototype.
+                ref: f1f245f0eda23eee136f15d498361e7a21040384
+            ironjacamar:
+                rationale: Part of the first base-runtime prototype.
+                ref: c7c51b90bfcaffa6cad3c9489c650a4c4cc3961d
+            iscsi-initiator-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 643c2763067d75b30491d2704f855a98682406ce
+            isl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 29ea7bf09c34387f80943c01e5d4ee9702249b7a
+            isns-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: e8ab9d1655fd6661e84bf81065f101a99136cf23
+            iso-codes:
+                rationale: Part of the first base-runtime prototype.
+                ref: d17e5665d423cfe9e42296cd4a809995e5441066
+            isorelax:
+                rationale: Part of the first base-runtime prototype.
+                ref: 042c7d27a3c7e01ebbd650a6afcb12d292a46f59
+            istack-commons:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4983593610d706de475d59236efb1ef24717983e
+            itext:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6b90a65248803f84f684933eacd1349ca8a422e6
+            itstool:
+                rationale: Part of the first base-runtime prototype.
+                ref: b6a41eac0970f91f689828e3bb330648d2c4ba50
+            iw:
+                rationale: Part of the first base-runtime prototype.
+                ref: d3fdce098715a7e3a23f342973d8302c4c122e8e
+            jack-audio-connection-kit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6f0d7a32334dc8c9fe03f91219c05b1ee69b6fa5
+            jackcess:
+                rationale: Part of the first base-runtime prototype.
+                ref: 45e1c14bcb1fb0a6052ccfa3d5ea220b6517a761
+            jackcess-encrypt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 60b9687cca6d881f9d1d1754fd885fbfd72bba1a
+            jackson-annotations:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4a5a6f5461902c048fe26767e19ab8c0cb2ce53a
+            jackson-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: a34a1d27fd5568d556e9e909c7ced2e9cace47d1
+            jackson-databind:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9c6cc24a2e3f4250a17e9413772e893f15ff265f
+            jackson-dataformat-cbor:
+                rationale: Part of the first base-runtime prototype.
+                ref: 23209da99a3fcc9458a9148d5f397f3eca1d3682
+            jackson-dataformat-smile:
+                rationale: Part of the first base-runtime prototype.
+                ref: b2bf90eeb44d3cee16e8211ecb7c7647bcd674dd
+            jackson-dataformat-xml:
+                rationale: Part of the first base-runtime prototype.
+                ref: ec717faefd2a7d77b42a6bcc5dcc5f19919099db
+            jackson-dataformat-yaml:
+                rationale: Part of the first base-runtime prototype.
+                ref: 008a98d163533a22ed37de85ad5f67ec5df7d07c
+            jackson-datatypes-collections:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7345710ec30c15e4564f080194fa38397bf451b9
+            jackson:
+                rationale: Part of the first base-runtime prototype.
+                ref: ed0de89e873a71b5c5db4e00b64e81b6c9f957a3
+            jackson-jaxrs-providers:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5b8990c8578c00c6b55ea387a613e85ca9686580
+            jackson-module-jaxb-annotations:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4aeebc717217be6c64c9fe7336d30c984920c4ab
+            jackson-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: b74531846d58417c66a914a274d37a7a200bfaf9
+            jacoco:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8c7e9eb60b54e7e4acac7b91e4b14cbc45148244
+            jacorb:
+                rationale: Part of the first base-runtime prototype.
+                ref: a02b646f57cbdc84a69db69813d0f498ba7c7cd1
+            jai-imageio-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: d0fdc107c075423755858deaa8982d1bf144dc00
+            jakarta-commons-httpclient:
+                rationale: Part of the first base-runtime prototype.
+                ref: 41d33d9979114f684046cf9ee57314ef63c9ab94
+            jakarta-oro:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0846666a17ede960f208789a8cfcee1d2eb45d95
+            jamonapi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1e1ff7bb570e91e81458c87af223800c8b6e2bee
+            jandex:
+                rationale: Part of the first base-runtime prototype.
+                ref: c9d1008ebb0857c614c6b4e37c87cac87b65a1fe
+            jandex-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8cb70a2012555933055870cf2a4ddeb59375e934
+            janino:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9f48425ba2f3bb416cae3e0d69c21c0f73f26a55
+            jansi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 12e01d3b929779f1fc1dbcbd19104ab769635f7d
+            jansi-native:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0eb31860ea54f556c298266bf1a5fac2a03f48d6
+            jansson:
+                rationale: Part of the first base-runtime prototype.
+                ref: 548de6039d0cb206fa64748400dc4f4163dcaa6f
+            jarjar:
+                rationale: Part of the first base-runtime prototype.
+                ref: e46dfd81d1d7fdae4a3fae2297af609b99186580
+            jasper:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1c22196677cd8d7792dc7ce2a716393063677eb6
+            jasperreports:
+                rationale: Part of the first base-runtime prototype.
+                ref: 52495a2f4b8a263e1299fb385e679bd76d4c5d5c
+            jatl:
+                rationale: Part of the first base-runtime prototype.
+                ref: cf4da74898e7dfa7ae20c4dc744da480c82409a7
+            java-1.8.0-openjdk:
+                rationale: Part of the first base-runtime prototype.
+                ref: b5dd13916b5d561c4cecba6b6a5ceeec9913793a
+            java-base64:
+                rationale: Part of the first base-runtime prototype.
+                ref: a3728f7ee1985e63293b20881a7c6b0ff6db72d7
+            javacc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0807c6e3722b2aaf779bf6e59beaaf2aedcf7734
+            javacc-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: e185c0f04bf5aaab9fe45cda515901677514d7a9
+            java-comment-preprocessor:
+                rationale: Part of the first base-runtime prototype.
+                ref: f8e2f80f8cb2698bd9dcb68c5e6a12fa29ef532d
+            java_cup:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0806e53b3e23b7423e258a933de5450f26fd59ea
+            javaewah:
+                rationale: Part of the first base-runtime prototype.
+                ref: c0fffcd695a0ea26c525eda242b1827d4cd28c81
+            java-libpst:
+                rationale: Part of the first base-runtime prototype.
+                ref: 71e26a6643c1abe9ff49bfcc7687ed0497aa5d2e
+            javamail:
+                rationale: Part of the first base-runtime prototype.
+                ref: fd385ebfe7e5033bb0de4252516fd0ef01b78c62
+            java-oauth:
+                rationale: Part of the first base-runtime prototype.
+                ref: c957b6d3087822a2651d3175cc83694b097452ad
+            javapackages-tools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0d7c99a5eae8a6c256eac1ce46ed291d08ef96fe
+            javaparser:
+                rationale: Part of the first base-runtime prototype.
+                ref: d56bca755ab55adb86db74bffe37ec0cba54830f
+            java-service-wrapper:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7b41ae99e211bb92cae95d831a5bdbd10b5b1f92
+            javassist:
+                rationale: Part of the first base-runtime prototype.
+                ref: 63dde219db08d23ba7e4058e24644bed7d5fdd6b
+            javawriter:
+                rationale: Part of the first base-runtime prototype.
+                ref: f45fafb99cc6f803b2c1f35ebc3ab61df94e5353
+            jaxb2-common-basics:
+                rationale: Part of the first base-runtime prototype.
+                ref: 13caff11899e700ec820ca6d2b86414754ab78e3
+            jaxb2-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5d47d3c36c67afa18efa40d4b669eafc80fb8a02
+            jaxen:
+                rationale: Part of the first base-runtime prototype.
+                ref: a6705a3e0f80fa4cb31c70a2981382a96cd13298
+            jbigkit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 97dcfffe2a9f163bb24e62ddf5b7389ef64763c8
+            jboss-annotations-1.2-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2cde9e420a95c65058b4c9f3afc039309026a69b
+            jboss-classfilewriter:
+                rationale: Part of the first base-runtime prototype.
+                ref: 756a77c34655acd48fb4a143babe14936a97d397
+            jboss-connector-1.6-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 23d7c9c4182251123415f09b2edf23b7c9de991e
+            jboss-connector-1.7-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: b9247412cce576f98c7a2443258773d954b8d247
+            jboss-dmr:
+                rationale: Part of the first base-runtime prototype.
+                ref: 85140a2d90bce7e7088d2438b2495f440619d48b
+            jboss-ejb-3.1-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: fb5a684831997a91c8ac33d48986c062e63df46d
+            jboss-ejb-3.2-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 59f1a3247328a5c3b1c65268c6a06c460a66808c
+            jboss-el-2.2-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: ceb7fb2e593afbab876f953276c4f216a6889503
+            jboss-el-3.0-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 793b8e8d98d045bfb29765cd6de57ed0f085674b
+            jboss-integration:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1c64900af23da9ba45827c3f17adea35562d7625
+            jboss-interceptors-1.1-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6fdc5cb3ecbd547dfb9c6b76a7d1a28603729f81
+            jboss-interceptors-1.2-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: d30fdcffb9ef572eb9acbbeb0abf591c01f67f7a
+            jboss-invocation:
+                rationale: Part of the first base-runtime prototype.
+                ref: 082a739f38808bcee9ee4823e7ba94fa71c6102c
+            jboss-jacc-1.4-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: c0888c4ed399f3b365aa206123ffb0bebc048363
+            jboss-jacc-1.5-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: dcd224765eea877624ff40a4199af036b5fb8fd2
+            jboss-jaspi-1.0-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 87b69dab37e4d352185b73f86fa5949eb7e58d63
+            jboss-jaspi-1.1-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: bc67d9cbfc5f3ac507757a81097a381557730f75
+            jboss-jaxrpc-1.1-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 077cdaf4bb0ef8052b83a16bbd3648b7793e5bb8
+            jboss-jaxrs-2.0-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 365767aa4989ccda241ffdf860aaf630ce9a4f81
+            jboss-jms-1.1-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8a3f02c63b1a4e7cf313372b10c408d6739889ae
+            jboss-jms-2.0-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7a52dc680254bc3f0f60293742db7a4a0676860f
+            jboss-jsf-2.1-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: f7f0ed89cb7853d110cffe10f56ee6158ce354f6
+            jboss-jsf-2.2-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 97cfdba81b5fd075d950afb5b64b523313f9a9cc
+            jboss-jsp-2.2-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: a575644035335b2aa6cb34ea428b90a48e348e96
+            jboss-jsp-2.3-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 049b4d1de4226cfe4ad2cf31bf5eed7e15b9c95a
+            jboss-jstl-1.2-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: fbfb71666b9162453ee741db8feadf7d30a19682
+            jboss-logging:
+                rationale: Part of the first base-runtime prototype.
+                ref: b859a2c362891cd92cc4eeaba255a9298e2441ef
+            jboss-logging-tools1:
+                rationale: Part of the first base-runtime prototype.
+                ref: 707d3799d11d9e74d78113b741bf3305acbd6b20
+            jboss-logging-tools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 75e7de75fde69f456b185c0e8bf6d09265103259
+            jboss-logmanager:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94d65d96aef1b518b71f73994dbd7511a054a8e2
+            jboss-marshalling:
+                rationale: Part of the first base-runtime prototype.
+                ref: a4bc33d6bc1905488ab8c995abfaad3aff1135b9
+            jboss-modules:
+                rationale: Part of the first base-runtime prototype.
+                ref: a2f71c9cbc649a42231f685dcc2c52b4a77efd49
+            jboss-msc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 23beb1c71084cb37017556b19783c70bdd996d26
+            jboss-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6bfc0e9d0eb48bb5ae31c5a912cd15b3cd6c726e
+            jboss-remoting:
+                rationale: Part of the first base-runtime prototype.
+                ref: 78fb34a18d920b1c5d6d09964e74ccf2db379051
+            jboss-remoting-jmx:
+                rationale: Part of the first base-runtime prototype.
+                ref: a5a69ae9bf7b241654c92e81b34c65e66ec0c270
+            jboss-sasl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 19b75309d2b2e1dcb1e26fcb167acee1e4262f61
+            jboss-servlet-2.5-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9bdaed0f9429e603bc3645a73ca16a7098541b71
+            jboss-servlet-3.0-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: b9b74f86ea73a1fb46557ef21a3be26c5bf5ad4f
+            jboss-servlet-3.1-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: e2c5dd9dbf665a3d482b5ecc73dfd8d0800e61b1
+            jboss-specs-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: de91a75e06d3099b55706c59105ed82890dceaf2
+            jboss-stdio:
+                rationale: Part of the first base-runtime prototype.
+                ref: 21417fdaa30aebcd811ffc7afcf20cadee7744ba
+            jboss-threads:
+                rationale: Part of the first base-runtime prototype.
+                ref: fdac62853bcc7bf2afbaae162d6d75607879cb17
+            jboss-transaction-1.1-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: bd0f5cd6d807cf244a5c03ae71a185e3c164748c
+            jboss-transaction-1.2-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: a9065869bf3a964edf0df06e24a2952bbece22ec
+            jboss-transaction-spi:
+                rationale: Part of the first base-runtime prototype.
+                ref: e22ce639843dd8e48917068b712e0abc9166f302
+            jboss-vfs:
+                rationale: Part of the first base-runtime prototype.
+                ref: bea234d1d205b3d21465ebb042bcfc1959b0f2ee
+            jboss-websocket-1.0-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: b168ecf07c1f7232d5440a49207f39f842f07896
+            jboss-websocket-1.1-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2b5fc37ff09853b6df0c510cba0d833de17ea7b7
+            jbossws-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 34e4a1d3bb914f3f6bac380d75e8721e7a6ba7bf
+            jbossws-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: b9cd6aeccda0c5bdec062474ec8f299c5dbd42b2
+            jcifs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 30b4813a25ac9253b288622c4f1c86f366214f5b
+            jcip-annotations:
+                rationale: Part of the first base-runtime prototype.
+                ref: b55c72a8e2b2af3f02943be985a87334386c4152
+            jcodings:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8f74922a2863dbd43356161303d7061d0618ed4b
+            jcommon:
+                rationale: Part of the first base-runtime prototype.
+                ref: 299cbfd95017ec579b63df5cbc7dadfb93c79c9b
+            jcsp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8ca36685d271276b361a797c3b07c6a61962189e
+            jctools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 015a7068abda27dcc568c603bdbedeb5f73d82c7
+            jdbi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 21feff0a2b549fc263564660ec1dd730a5f02124
+            jdeparser1:
+                rationale: Part of the first base-runtime prototype.
+                ref: ae05c52e99b12f1965693f04ee42604c2ee89d83
+            jdeparser:
+                rationale: Part of the first base-runtime prototype.
+                ref: a1718c03e48fb899183bb75ef4e1edb0508307f9
+            jdepend:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5f1d2c419fd3a707629966e49f399d4b52160cc6
+            jdependency:
+                rationale: Part of the first base-runtime prototype.
+                ref: cd2ed0bd8cb244961fae1b1a0c0a8de36c182607
+            jdo-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: d7d899241e90b55dcf6396542ae807575b4b6623
+            jdom2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 861e2cbd550cc70bbf9be0ebdefc902e053a8750
+            jdom:
+                rationale: Part of the first base-runtime prototype.
+                ref: cce6fef8e96cdd8d8590b121fb347525bc6cfe72
+            je:
+                rationale: Part of the first base-runtime prototype.
+                ref: abbc3ccfdbf3b9e9bbe801f174db15c81296d8a2
+            jemalloc:
+                rationale: Part of the first base-runtime prototype.
+                ref: ccade2a2ac4949b481cdb989f7d9d89a5fdff452
+            jeromq:
+                rationale: Part of the first base-runtime prototype.
+                ref: cca252bd8846a3de8c245648c49ab113c380812d
+            jersey1:
+                rationale: Part of the first base-runtime prototype.
+                ref: 93fa7b91b082361a3fcc00ba43e0e8a88a2364ad
+            jersey:
+                rationale: Part of the first base-runtime prototype.
+                ref: be86cc382fc754b063a35c25196b0dea61f62457
+            jetbrains-annotations:
+                rationale: Part of the first base-runtime prototype.
+                ref: 43f5c028dd1144c8476ed1bcb534fc9d83d8c45c
+            jettison:
+                rationale: Part of the first base-runtime prototype.
+                ref: 86c834db4687239709e647c02573bf0403268b76
+            jetty8:
+                rationale: Part of the first base-runtime prototype.
+                ref: 28d495ff628a1865c83f89b01bac08f73434ec32
+            jetty:
+                rationale: Part of the first base-runtime prototype.
+                ref: ad37a782f54597c810b820af28bfe21ca2cada5a
+            jetty-alpn-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 80f52590054453b879ec49a022117c52cc6dce18
+            jetty-artifact-remote-resources:
+                rationale: Part of the first base-runtime prototype.
+                ref: b49804c61e9ea589fddecea617989e370cf02a6b
+            jetty-assembly-descriptors:
+                rationale: Part of the first base-runtime prototype.
+                ref: 684fbf446d53603a1047aa17cd26514ad575e3a7
+            jetty-build-support:
+                rationale: Part of the first base-runtime prototype.
+                ref: e935a7837787ce6a695163d6ce6faaac34b1a3c1
+            jetty-distribution-remote-resources:
+                rationale: Part of the first base-runtime prototype.
+                ref: df7a12289566026595002ca759fe16147dc3f151
+            jetty-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 527529bcec35e0c2806177bc8d8664615cde4a92
+            jetty-schemas:
+                rationale: Part of the first base-runtime prototype.
+                ref: d4a84698e038ec0f6657d7f90e44fa7f17127591
+            jetty-test-policy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 510c76e32e3cf280b6b3addde63f50af1c0abc62
+            jetty-toolchain:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7847ccc4c2c3c1a44754d4536cf822561f6ce8ed
+            jetty-version-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: f94161d309f1b56f239f6ec94431feb912286ec1
+            jexcelapi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 44dae5ee79743e9658e17defa4e472c6ef906bea
+            jffi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 888c44d0d6f1d90d02dc884f86ea910fddb5896a
+            jflex:
+                rationale: Part of the first base-runtime prototype.
+                ref: bd89f801a42ebd0e9b8be0eef25f964e813ffff1
+            jFormatString:
+                rationale: Part of the first base-runtime prototype.
+                ref: 98b47f14e41aa21c8bc914d066816a3aff5163d5
+            jfreechart:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1e95298b7fc3185982bfd2e43a6d8dbc41cb5a10
+            jgroups:
+                rationale: Part of the first base-runtime prototype.
+                ref: c276fda791e4a62462f6badfd47eddfd8bef21c6
+            jhighlight:
+                rationale: Part of the first base-runtime prototype.
+                ref: e7ca6d5a5d5af67d7c17184b8904435570b496a2
+            jibx:
+                rationale: Part of the first base-runtime prototype.
+                ref: bf85b1027431fe5ffe47489575236ffe46008395
+            jline1:
+                rationale: Part of the first base-runtime prototype.
+                ref: 08e8bb1a63cb9de736e8b979e1c80a1241f72649
+            jline:
+                rationale: Part of the first base-runtime prototype.
+                ref: 76125f11973253395dd2cd10f9131dc1854dc96c
+            jmatio:
+                rationale: Part of the first base-runtime prototype.
+                ref: bf1064ec92fca80bbc53ae1ab1d3d9941979332c
+            jmh:
+                rationale: Part of the first base-runtime prototype.
+                ref: ace6e72c2d597af0fe1c571074cfdccf602b55ca
+            jmock:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5e399fe52b1dee4c4eec258b11038d75e6f2bb6c
+            jna:
+                rationale: Part of the first base-runtime prototype.
+                ref: 83c54cb0234d58f5467fdced5d9fd113983b325b
+            jnr-constants:
+                rationale: Part of the first base-runtime prototype.
+                ref: b41a856bf64210f4b6a5e21e9452cd65372a6598
+            jnr-enxio:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0ec9fb8bd9be5b3584ba128b4e84b7942f497faf
+            jnr-ffi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 860a6842b55a8e09bc1358092d9556b4a6c33ac1
+            jnr-netdb:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6e26546adc4b07858b575db93b902758e7d266d4
+            jnr-posix:
+                rationale: Part of the first base-runtime prototype.
+                ref: 31d4f1c52e14b2e164222a9202c26575a838e8d2
+            jnr-unixsocket:
+                rationale: Part of the first base-runtime prototype.
+                ref: f73ba44fd5915570c841cecf145d07c089e9796c
+            jnr-x86asm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 63e9fcc657f17e1d6def32876aeb597466091333
+            joda-convert:
+                rationale: Part of the first base-runtime prototype.
+                ref: 65ce85eb9226afe69fbfd3d2359edad817eaca5f
+            joda-time:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4dd3da430d2bc1db2105309711a235c5e3cf768f
+            johnzon:
+                rationale: Part of the first base-runtime prototype.
+                ref: d4ecd88b5bdab15b5bdb5d53d6df13b2e247d36b
+            joni:
+                rationale: Part of the first base-runtime prototype.
+                ref: b6fd685bead95cb21938af0c327f2ac8e8bf739a
+            jopt-simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: a1ccda0e0554aa4df898233da385e8fc7fa9d67c
+            jq:
+                rationale: Part of the first base-runtime prototype.
+                ref: 939a076801ee09d80039caadc3efe84a862db82c
+            jruby:
+                rationale: Part of the first base-runtime prototype.
+                ref: 37a7c8d0e116964490bfc26ebebdfbff0d42df06
+            js:
+                rationale: Part of the first base-runtime prototype.
+                ref: 60d6e06473284809fe7c47620c9a686abf55b099
+            jsch:
+                rationale: Part of the first base-runtime prototype.
+                ref: a659411b45a2d02d48c959268fb3d2758cce4663
+            jsch-agent-proxy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7bb3622a5ecf4823095df953a1dca32c08aed434
+            js-jquery:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1d0bf2d82f18f7e0086890652d0da666eb4414d9
+            js-jquery1:
+                rationale: Part of the first base-runtime prototype.
+                ref: d8a046db53fad13bf8b4fb4807add7060151a58f
+            json-c:
+                rationale: Part of the first base-runtime prototype.
+                ref: 77fa2eca4d98ecd1440cbb78228e2fe0d2a21540
+            jsoncpp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 065c622898604530a2c67afc9b9d2fdcdfc935ca
+            json-glib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7c6ade31694da757c6e7093adbfd4797f110063d
+            json-path:
+                rationale: Part of the first base-runtime prototype.
+                ref: 658baec74593c58e1e368923d329ba8a63f4557e
+            jsonp:
+                rationale: Part of the first base-runtime prototype.
+                ref: ca86ff3b4ba8288addd3a3acf5ec7542450a83cd
+            json_simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2af86207bc38b649450c4eac2f5f3bc88166f431
+            json-smart:
+                rationale: Part of the first base-runtime prototype.
+                ref: 984ea2404ca78317c46e1a429f498f47de580270
+            jsoup:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7ef968785c5cae1d247f903a0b70dbe8b547cc0e
+            jsr-305:
+                rationale: Part of the first base-runtime prototype.
+                ref: 36174cb33e1e80eb47c8f993459efce2f6daeea0
+            jsr-311:
+                rationale: Part of the first base-runtime prototype.
+                ref: d3350e6cff2ac1ece0da862c94224dcacefec3de
+            jss:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8ee225152202292503fab005050c3a92c061b541
+            js-sizzle:
+                rationale: Part of the first base-runtime prototype.
+                ref: 032c5e6cd00b47709b27f380bc047147ca538b30
+            jtidy:
+                rationale: Part of the first base-runtime prototype.
+                ref: b6f69228c4c839990409729622113e3f07ed4bb6
+            jts:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2dff2a25876ceb5de5292bafc44070eecc4e2080
+            jul-to-slf4j-stub:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6c298badbb84ab978511afc238d398ed1152315b
+            junit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3f9f4b41b5e4d2268bc4783c30ff129ad465d8c1
+            junit-addons:
+                rationale: Part of the first base-runtime prototype.
+                ref: 222ee43312c94172e59c70b48d08f430b0862977
+            juniversalchardet:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3aafd1ad66d1eeb44342f535d0a659b0c9604786
+            jvnet-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: beaecb767cae9bd142aaa6c66386c487fdff7eda
+            jwnl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 662e8e65f5be17fe90f4c4ceee309b30c0aa2258
+            jython:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3255c0d4ade1af82430ba3af25fbedf9a09a7770
+            jzlib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 46c03215985704690c31dd263788ed807eb3eea2
+            kate4:
+                rationale: Part of the first base-runtime prototype.
+                ref: f13276a02f085e674a178ab1146a4c354dd82056
+            kde-filesystem:
+                rationale: Part of the first base-runtime prototype.
+                ref: 250cc19d1544002e90afbd1e29957889706f71fe
+            kde-l10n:
+                rationale: Part of the first base-runtime prototype.
+                ref: 00e3a3132a09182a8163cd2a8c101681e6090014
+            kdelibs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6e27d7de5a79d774279f5b6ac62bf1ed0bbff6a1
+            kde-settings:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9bc5bb8dc43ee90b6ef77457a396bbeab8fbbdb1
+            kernel:
+                rationale: Part of the first base-runtime prototype.
+                ref: bce07081d753a137776da507e6bfa7b1d5b59f7b
+            keyutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3ea3658b5ea70c927d57c99b8eea949ea622bba7
+            kf5:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1ce46959e475211f7b5cd3f4fc7183023aa927d9
+            kf5-karchive:
+                rationale: Part of the first base-runtime prototype.
+                ref: b0f3e03a898ffa07f10ca6273e596ccf2f5b3a9e
+            kf5-kconfig:
+                rationale: Part of the first base-runtime prototype.
+                ref: a850d76a76a269d5e252d6fe4b70880f74d3bd07
+            kf5-kdoctools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9bbf810a1d41b187451b03fdfb639287f7d35839
+            kf5-ki18n:
+                rationale: Part of the first base-runtime prototype.
+                ref: a18b8660b6e335c68041ab1a752f915855c6b370
+            kmod:
+                rationale: Part of the first base-runtime prototype.
+                ref: af396dff73f084ee55fcdfe4e771f72b7fc4669e
+            kohsuke-pom:
+                rationale: Part of the first base-runtime prototype.
+                ref: 977a07254ca9eec2c03f040571a3d3c1553e430e
+            krb5:
+                rationale: Part of the first base-runtime prototype.
+                ref: f54367ad9d130765eaf026ddfa32513086845a63
+            kryo:
+                rationale: Part of the first base-runtime prototype.
+                ref: e9a84488646b1dabdd05d5620018d09c7d4e248d
+            ksh:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5a2e74c74a4335e7c40303890d636a56c9f87438
+            kxml:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9858b1914d26f3c4f15becb11283b84561450d43
+            ladspa:
+                rationale: Part of the first base-runtime prototype.
+                ref: 46fad7c19ba0543a1685541d51fffd5ab87cfab6
+            lapack:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7e703de54ef6b5170765c089279765d68a0a4ccc
+            lash:
+                rationale: Part of the first base-runtime prototype.
+                ref: ef73820a1b93144d905160764d61bba5a0266b62
+            lasi:
+                rationale: Part of the first base-runtime prototype.
+                ref: cd0295058cca9598113e09936e9ad010740def07
+            latex2html:
+                rationale: Part of the first base-runtime prototype.
+                ref: d418f99914c6e22cfd984cf6005e2fb68bb4f46e
+            lato-fonts:
+                rationale: Part of the first base-runtime prototype.
+                ref: bccb143226a28a8a91fec69c635facdd630b0e28
+            lcms2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 01f14c61da424f8a603973d3f71d917f6e0b7c40
+            ldapjdk:
+                rationale: Part of the first base-runtime prototype.
+                ref: 154b0f8185c1979578cc5c62e5e51b4574bec88f
+            leptonica:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3d0a9db13a1cc7260fd92743ebf4f78f9b1d7c13
+            less:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6502b093ba9459375ebc463a7d256fa9e6718d00
+            leveldb:
+                rationale: Part of the first base-runtime prototype.
+                ref: e32dfcc74b9177b6c8df1e0032b9600af0d0d1fc
+            leveldb-java:
+                rationale: Part of the first base-runtime prototype.
+                ref: 490fc7d051041c70fa7a69c4d5e985a5f575f1b0
+            leveldbjni:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2a1d5b80774d2cbf7a776b62ca262e97080fe095
+            libaio:
+                rationale: Part of the first base-runtime prototype.
+                ref: 97f51c1adc513d626d4fb49f0e31b622933d20de
+            libao:
+                rationale: Part of the first base-runtime prototype.
+                ref: 00b7b181e857e1493e3e2c7f50a843b50802cde0
+            libappstream-glib:
+                rationale: Part of the first base-runtime prototype.
+                ref: d07c93c032b3b4f8a9e1962b882f9aba80f55f2f
+            libarchive:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8076f226f80bba7550e93469dac1d09eb748f9b9
+            libart_lgpl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9ebe7e55d556f24b958e2222acc5fc029aadc500
+            libass:
+                rationale: Part of the first base-runtime prototype.
+                ref: 36ffe42600cf5f9f16c2eb02e09beb5a5cf38cc8
+            libassuan:
+                rationale: Part of the first base-runtime prototype.
+                ref: 49e1858991461c341977415cb7d9c66074769143
+            libasyncns:
+                rationale: Part of the first base-runtime prototype.
+                ref: a87ef432de46e3be31655dccc16bf9f0d7e8318d
+            libatasmart:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0d3b041571f715ebf39d1ec26b2749fd547ea5b5
+            libatomic_ops:
+                rationale: Part of the first base-runtime prototype.
+                ref: f99fb88db9d607ccdf23e17f6f423e36330a9508
+            libavc1394:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8576075f42e6d3ac9a72486374ade2bfa2d7df5b
+            libblockdev:
+                rationale: Part of the first base-runtime prototype.
+                ref: abac63e4955bf0bd0bf8980945d73ae2fa19dae1
+            libbluray:
+                rationale: Part of the first base-runtime prototype.
+                ref: dc0e7509206e23c6d83869dae91fb364505f0a28
+            libbonobo:
+                rationale: Part of the first base-runtime prototype.
+                ref: b0eab5a23ede69d91b152d86040cbd57dcbb91b1
+            libbonoboui:
+                rationale: Part of the first base-runtime prototype.
+                ref: 53f7446dcd0c8a9f9e7d944649a052bab4298a11
+            libbs2b:
+                rationale: Part of the first base-runtime prototype.
+                ref: ff9c10ad7da777febef4a19686941047f9a0b238
+            libbytesize:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3075a1462ee785c66baa8778ca65748f4f02cd31
+            libcacard:
+                rationale: Part of the first base-runtime prototype.
+                ref: f87ff2234252edd4fc6b837e835d3c126a159c93
+            libcanberra:
+                rationale: Part of the first base-runtime prototype.
+                ref: 11e699d60c722d0e94f1600a8c2e18ba996cd04c
+            libcap:
+                rationale: Part of the first base-runtime prototype.
+                ref: b4907a9c77373163c84f9ea7a064a34f7dd4fd4c
+            libcap-ng:
+                rationale: Part of the first base-runtime prototype.
+                ref: cccdd40acf41fab50fedb7cf4a62afa97da28581
+            libcdaudio:
+                rationale: Part of the first base-runtime prototype.
+                ref: ec55cbfcada9465648656b002401b2e43e021f95
+            libcdio:
+                rationale: Part of the first base-runtime prototype.
+                ref: b4d3b604481f3d0845babe5c164ddaf6d07eee3e
+            libcdio-paranoia:
+                rationale: Part of the first base-runtime prototype.
+                ref: f1ab2f5e33fb76df6e07f95d16d71380521aff20
+            libcgroup:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2f31f5778651e84f93b65fbd2bef980a00b7ca61
+            libclc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6eaf12d48fe64c0dfa744ae2fc4c2c0479d2cf22
+            libcomps:
+                rationale: Part of the first base-runtime prototype.
+                ref: 054d2758327e41afb2bae1094be8e7421f76612e
+            libconfig:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1db07ab3dbd3a5dbc812cc67f90fa4c8a39452c5
+            libconfuse:
+                rationale: Part of the first base-runtime prototype.
+                ref: fcb2cc1576b7a1ba79e9fffad2f353635df09766
+            libcroco:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3572bb29840d15ba58abb0ac7405a2e63296c87f
+            libdaemon:
+                rationale: Part of the first base-runtime prototype.
+                ref: f7b4f4e20311117c688f1c0ee3994b75eb1fa0e6
+            libdap:
+                rationale: Part of the first base-runtime prototype.
+                ref: 39935ff19bf4d2733c92596797461a8f9bf9bd5f
+            libdatrie:
+                rationale: Part of the first base-runtime prototype.
+                ref: 75606432e1c2f57aaa7e1326973ee434a84e1aee
+            libdb4:
+                rationale: Part of the first base-runtime prototype.
+                ref: e8bbe0d6e27123c940a1fe88fb89a0402c45a194
+            libdb:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5720605fb2b59ffb8f011652aa5abc4c9a53a9f6
+            libdbi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 056e8df0702ed347303794d6cdbbf3762f0f77fe
+            libdc1394:
+                rationale: Part of the first base-runtime prototype.
+                ref: 14f4e50b8c92f6d030021d0ae7d43710901e6ebc
+            libdmx:
+                rationale: Part of the first base-runtime prototype.
+                ref: 662b9b403eb2aa1d150bc861354cb22c1fe2401e
+            libdrm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6c3eebd951dae3f783d12ba90761ee1378c052bd
+            libdv:
+                rationale: Part of the first base-runtime prototype.
+                ref: 38332bc2ef0a9221b36c4a235cd222957a5a8750
+            libdvdnav:
+                rationale: Part of the first base-runtime prototype.
+                ref: 966b2bbcb810bca9b5c7dd08692abebba1b1c80d
+            libdvdread:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3bc9cdc4e0f772049bd8319c34f5633054cbb45f
+            libdwarf:
+                rationale: Part of the first base-runtime prototype.
+                ref: ecde3fb595ea5fc5a46f2cba4a7a402e2d5811ed
+            libecb:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0ea5b5e59c185cb00c0a478b69e2baf94e1e8967
+            libedit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 99838cbeb9018bc677e7fa5902e956d74bc011b8
+            libee:
+                rationale: Part of the first base-runtime prototype.
+                ref: db680bacd26c15f8ccb5b15a6f501e12e5d8fdc1
+            libEMF:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3fb5985852b2e4ac70953780f994d3088dcfafb6
+            libepoxy:
+                rationale: Part of the first base-runtime prototype.
+                ref: eb76efecabd1832759897f1555a68bc2091110f1
+            liberation-fonts:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1ebbdfefa9ab231a6f13a58e39497a20f9c6e0a7
+            libestr:
+                rationale: Part of the first base-runtime prototype.
+                ref: ed63ddda19fb3a181cf8fc8040e0838b67f33af8
+            libev:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8be62820a2115bc19bbc12f981f9600c14b99619
+            libevdev:
+                rationale: Part of the first base-runtime prototype.
+                ref: dfe8380ec64e47e2a68d711bc47921b50fc0620f
+            libevent:
+                rationale: Part of the first base-runtime prototype.
+                ref: cf266e2224513c5055c2a533aceeb0453f8aef87
+            libexif:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0139df43b83626fa7cf8bc9f6b0502eb4f087970
+            libfabric:
+                rationale: Part of the first base-runtime prototype.
+                ref: 42226f9cc5a9d7aad473626027f7450a5bdb2bec
+            libffado:
+                rationale: Part of the first base-runtime prototype.
+                ref: afff2e5d5d209cf15afd8ca3db667d84fc3eb1f6
+            libffi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 18d9d42129d3549a8ae38e8d1774f02f9ac2feb1
+            libfontenc:
+                rationale: Part of the first base-runtime prototype.
+                ref: e3425b484fd914d5e439c99c8ec60e860e35b668
+            libftdi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 60a5f3cf2630996693c0e66b5bc58f9c44fb8eb8
+            libgcrypt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 055651971a7c6a9c421fe508f7df5e1928870a81
+            libgdata:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5fede50419c8983545d1541db31208d58abc4c32
+            libgdiplus:
+                rationale: Part of the first base-runtime prototype.
+                ref: c6eafe907a473e5a479e3ff556d3c68ae82b9ec4
+            libgeotiff:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8c70db54d7b82a5277b8dac4fbabc9d49c84ef29
+            libglade2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4c37b1b0612390b8af4e714704b8fd1449cdc445
+            libgnome:
+                rationale: Part of the first base-runtime prototype.
+                ref: c6eeaf4b5bf3b0b866e0638be91a27757fef6bfb
+            libgnomecanvas:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7c9c7b355138ee7b7fe5a0b9a091d30b8d32620a
+            libgnome-keyring:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7333fc9a9bf74a215299abd7c8d03ece88a05652
+            libgnomeui:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0f6def42aa57ecc0480cb1f789904c441471cb7c
+            libgpg-error:
+                rationale: Part of the first base-runtime prototype.
+                ref: 037c370b3db83c8c229e09eae3557fc7ff244192
+            libgphoto2:
+                rationale: Part of the first base-runtime prototype.
+                ref: b910f65997443be59115b694040bf60947a36875
+            libgta:
+                rationale: Part of the first base-runtime prototype.
+                ref: 38aa8fbdb40a76bd01c6954119086f5f52b7ba8a
+            libgudev:
+                rationale: Part of the first base-runtime prototype.
+                ref: ae15b116238578e5b70be483ce99d57357b19b39
+            libgusb:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1d51553c14d303a5a880dab2bfecd216a944cf93
+            libibcm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0e5b060be3bb04dab0186c912b509063c64c0756
+            libibmad:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8f540f4abdeb7531c3f249e90d19e95ee0835680
+            libibumad:
+                rationale: Part of the first base-runtime prototype.
+                ref: 622a0c46789211c960701d8712298807199956c4
+            libibverbs:
+                rationale: Part of the first base-runtime prototype.
+                ref: acbf622c72bc6adbde61e8ea5a52d447ba567e35
+            libical:
+                rationale: Part of the first base-runtime prototype.
+                ref: 074ff364de86fd06b069f978056e45f5ae91d887
+            libICE:
+                rationale: Part of the first base-runtime prototype.
+                ref: b70b2ffb792b4c7aac7854f5f234c6fe9dbc6c6c
+            libicns:
+                rationale: Part of the first base-runtime prototype.
+                ref: 410e5a0bfecccaaaa3c38b0ac07b9b6738fd3184
+            libIDL:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5d9b9ada9415ec8c3118bb3cefe24d3b114ea838
+            libidn:
+                rationale: Part of the first base-runtime prototype.
+                ref: 08e4560e83bd66570a960f336402c7afa1236dfd
+            libidn2:
+                rationale: Part of the first base-runtime prototype.
+                ref: c1cd313f324c3a0626bb78f9382448cf979e2bc2
+            libiec61883:
+                rationale: Part of the first base-runtime prototype.
+                ref: 090753b5fbeabd18bf0596027fa2169d1ffee617
+            libimobiledevice:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9e7f0cb4529c489071cb713ec5a54d0c872f3e41
+            libinput:
+                rationale: Part of the first base-runtime prototype.
+                ref: fe775bd2e0797cbdf4fadd6f4afeeee10c0dfe77
+            libipt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 08645c70340c804b5cb69b4b15947a8d92168bc5
+            libiptcdata:
+                rationale: Part of the first base-runtime prototype.
+                ref: b7fea57adb0d2493062e05d408c7d77222d502a6
+            libiscsi:
+                rationale: Part of the first base-runtime prototype.
+                ref: e8ec237b1337444b9e1393e15dabcb0021a384c3
+            libjpeg-turbo:
+                rationale: Part of the first base-runtime prototype.
+                ref: 927c976b55bf47c6afa7f41c4338a9477df91783
+            libkate:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2ce8e19c2e46a4391a09648446686b8def14ffe6
+            libkml:
+                rationale: Part of the first base-runtime prototype.
+                ref: c6c08e218ad2c5779bce46a8c05120e866152353
+            libksba:
+                rationale: Part of the first base-runtime prototype.
+                ref: be64e8d031bdd0902a279a95d0872b211b168f78
+            libldb:
+                rationale: Part of the first base-runtime prototype.
+                ref: a93c09160bc54c45359100ee1b2cc3c4a8f02665
+            liblockfile:
+                rationale: Part of the first base-runtime prototype.
+                ref: 917e4d30ff14be89ab4ed4963d40d69520d0c48f
+            liblogging:
+                rationale: Part of the first base-runtime prototype.
+                ref: 554157969e3b12a368a0b5d5f402977beb5a818b
+            liblognorm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 411197100b61e42f307cb1f72f1183799492890d
+            liblzf:
+                rationale: Part of the first base-runtime prototype.
+                ref: aa24bb3fbf3e921cfd62cd318df8f00d85648d94
+            libmbim:
+                rationale: Part of the first base-runtime prototype.
+                ref: 95885b5a1253125692fe2d5334250fce26a0a6d7
+            libmcrypt:
+                rationale: Part of the first base-runtime prototype.
+                ref: efa6e0b14c8afae577465680fb500ba240166f8a
+            libmetalink:
+                rationale: Part of the first base-runtime prototype.
+                ref: cf16ef8c83140943f09b02cb0e99ce9decde9080
+            libmicrohttpd:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2d9a6fd42871b3eebab9101e4691db60d1026f25
+            libmikmod:
+                rationale: Part of the first base-runtime prototype.
+                ref: ae8ad8a109b17826f542b1301e92d49a4e090a78
+            libmng:
+                rationale: Part of the first base-runtime prototype.
+                ref: 762fd7b7dcbbbcb899d4d90aee03683eec1bdb2a
+            libmnl:
+                rationale: Part of the first base-runtime prototype.
+                ref: c822792941bf4b4a35bf6f6dae332f5ff02d8e57
+            libmodman:
+                rationale: Part of the first base-runtime prototype.
+                ref: fb9898a43a97dc689da3c0fa87bc1df8e14ce4f4
+            libmodplug:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8919da62b8db6e8b3df6c56975344c1ef5999f3c
+            libmongo-client:
+                rationale: Part of the first base-runtime prototype.
+                ref: ecaffc8ea5ac2b3a5e2d1ea7e3a05182a6046659
+            libmpc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 242106b44632a35f06193d82472eea39d0c91d19
+            libmpcdec:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5584b82790c340b446f1889baf33364d7845fe0d
+            libmspack:
+                rationale: Part of the first base-runtime prototype.
+                ref: a33650ed49867a4ba111501b023f18c06957afbf
+            libmtp:
+                rationale: Part of the first base-runtime prototype.
+                ref: f0a5fefd446bbcbc40c2bffd4a63520445736643
+            libndp:
+                rationale: Part of the first base-runtime prototype.
+                ref: fda173d7b9fa8425eae967f41a113e71bb298891
+            libnet:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9883d2b9806c10654d8ff77569c881dc79c7d766
+            libnetfilter_conntrack:
+                rationale: Part of the first base-runtime prototype.
+                ref: af5a71535d73800ebb0b4f21a27add4b714853c0
+            libnfnetlink:
+                rationale: Part of the first base-runtime prototype.
+                ref: d92fb6ae914144230911ff05985c5193f0a2d18a
+            libnfs:
+                rationale: Part of the first base-runtime prototype.
+                ref: b9773d7709a4a3f3c39abb3a2c8fc8bb9f3650cb
+            libnfsidmap:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0d5883102deba5ec5539ef0f2f5265ed17c752df
+            libnftnl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7d5c2bc563f46bd0f7d922fbc07daaf9a98fc87b
+            libnl3:
+                rationale: Part of the first base-runtime prototype.
+                ref: a5dbbb061fdbf59c5bc6797fdf6eff52ec643980
+            libnotify:
+                rationale: Part of the first base-runtime prototype.
+                ref: 746fa75980dbf208ebadf8813440939c45713292
+            liboauth:
+                rationale: Part of the first base-runtime prototype.
+                ref: fc2586de0e3c8d734a71093c0fe392c91789c5aa
+            libofa:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6ef9db4778418b79ff8a71ad557cc53850db4cec
+            libogg:
+                rationale: Part of the first base-runtime prototype.
+                ref: 32963a723cf3cbc9d9718fdca269e9137dfd79f8
+            liboggz:
+                rationale: Part of the first base-runtime prototype.
+                ref: 98764be044aae58389f88d9e0bfe4d0035d8f4b9
+            liboil:
+                rationale: Part of the first base-runtime prototype.
+                ref: 70f1ac556667c601a81d458a44e95c18db5b2d93
+            libomxil-bellagio:
+                rationale: Part of the first base-runtime prototype.
+                ref: abe45a20f86033c4a7673a4c2572542333f1fbf6
+            libotf:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2522a19fa8eebdf77968a509c6148d552ed362ce
+            libpaper:
+                rationale: Part of the first base-runtime prototype.
+                ref: bb3744743cf1940ab885a0a7f226bd40aecea81b
+            libpcap:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3bd9a6dc9f6cf8bea0d12ee137afc375510aa70b
+            libpciaccess:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0a716d5fcd6a5302525510b6822ec5543585a9fe
+            libpfm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 29a46f810486d914746dba3dac86fb6b7a66f43a
+            libpipeline:
+                rationale: Part of the first base-runtime prototype.
+                ref: b7b24b5368c3691b7f526262ea274657eb43ff0e
+            libplist:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1e9e47f66e0cb9aff3eab6e05b3eecdf92baefe9
+            libpng:
+                rationale: Part of the first base-runtime prototype.
+                ref: 88a9b908af6ea0808280bfaae0d5126ecc2b63f3
+            libproxy:
+                rationale: Part of the first base-runtime prototype.
+                ref: bc63a89dcc986bbed96a38976f0a41c71d7a8687
+            libpsl:
+                rationale: Part of the first base-runtime prototype.
+                ref: c7fd7383943573974f4f2a8e96d95d14c80dbff2
+            libpsm2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 103c37362fe0f327c1871e89280e77a0257c278c
+            libpwquality:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4343e518aadd6e27e48e82be850eb00e5d596951
+            libqb:
+                rationale: Part of the first base-runtime prototype.
+                ref: f69746a56d438b02342e03d29dc69a237b81a900
+            libqmi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 118e57e9bf8cdcbd6d2ac9e1a2c4735ffec156fe
+            librabbitmq:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4945d426d64da7ac2de1433b94856bf24cb7afae
+            libraw1394:
+                rationale: Part of the first base-runtime prototype.
+                ref: fdd3eceb488c34f741ee4de207eff90d09e614db
+            LibRaw:
+                rationale: Part of the first base-runtime prototype.
+                ref: 86eed27029ee21cc5d3da2c8ff072c4fc4b2cc18
+            librdmacm:
+                rationale: Part of the first base-runtime prototype.
+                ref: d3621f861c719f1a3e9c1c0a7fdda7395aa7add3
+            librelp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1552de43423370946c882d752f463d3f386998e8
+            librepo:
+                rationale: Part of the first base-runtime prototype.
+                ref: 13c4f6dda3d9e0e9596b31ac7b1ebc4122aa041b
+            libreport:
+                rationale: Part of the first base-runtime prototype.
+                ref: e9e272aaa2edfbab4e29443e68a392da82842193
+            librevenge:
+                rationale: Part of the first base-runtime prototype.
+                ref: 84b0d1fdab8b05cc6816b0f34d76de27261ebca2
+            librsvg2:
+                rationale: Part of the first base-runtime prototype.
+                ref: e0c0f7f2cf545391317eab697e0a902e172cd79d
+            librx:
+                rationale: Part of the first base-runtime prototype.
+                ref: e90fc5ceec545f4cfafc96bef8790831a3eb0b98
+            libsamplerate:
+                rationale: Part of the first base-runtime prototype.
+                ref: f50893810c1064ece708c38f8197d40e5017f360
+            libseccomp:
+                rationale: Part of the first base-runtime prototype.
+                ref: f9198826707825007acfecf990d458bfc3b3643c
+            libsecret:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2d3d43e317a08ec50f5f92b70e455d8062f7fa6f
+            libselinux:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5ad771ed687d0ab8fc998fd07693a5d27cbea143
+            libsemanage:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9a2ed658c82052d08def850e0f033622a1144330
+            libsepol:
+                rationale: Part of the first base-runtime prototype.
+                ref: d162105aae7220ead57314b3d11727da8a37da98
+            libserf:
+                rationale: Part of the first base-runtime prototype.
+                ref: aad0e585947b6186b5be62fe192d0dde8de36d14
+            libshout:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3c4984f111cfa3de2917e432d5f5203815fdea7b
+            libsigc++20:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9a592311eade0651b04ad33b06286799b26587cf
+            libsigsegv:
+                rationale: Part of the first base-runtime prototype.
+                ref: 304b57f61c7066a9ad0e2036798f899c8255143e
+            libSM:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6da3059f756f481911b4dd42e5b3447fed126042
+            libsmi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 223f2be75f7f7c93bb2dddf502fbbdcdde02b5aa
+            libsndfile:
+                rationale: Part of the first base-runtime prototype.
+                ref: 25bb38d4df5d2c29d2055a8de051f79a45525d68
+            libsolv:
+                rationale: Part of the first base-runtime prototype.
+                ref: c68db573dc511c125510730cbaf33cc77b157b08
+            libsoup:
+                rationale: Part of the first base-runtime prototype.
+                ref: a4bd0c03acedb9c91dbf89d4cca4cacb1f7d752a
+            libspatialite:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9a82b91f5e2aeb511b88f325d76aaafdcc3ae42a
+            libspectre:
+                rationale: Part of the first base-runtime prototype.
+                ref: 380715317b75f96c61b375bd5aaf2e8eaca50c24
+            libspiro:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0807c4a263a729386949db471b9793b54f012d4c
+            libsrtp:
+                rationale: Part of the first base-runtime prototype.
+                ref: d3e30294bebcf575aecd6e28da0791fe8ebc09d2
+            libssh2:
+                rationale: Part of the first base-runtime prototype.
+                ref: fa24637e03111b90868a95c847bc76b391063e60
+            libstemmer:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8c47c3c3d3bfc270d57d32afd0521e3b27feff5e
+            libstoragemgmt:
+                rationale: Part of the first base-runtime prototype.
+                ref: b8d352cce646f2e6fd9a449cb930607d4da2da5e
+            libtalloc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0c11dcc64577ccf8efba66254312423835805050
+            libtar:
+                rationale: Part of the first base-runtime prototype.
+                ref: 07a0534c951a7eb0c3cc0bb1aba42561238e40f6
+            libtasn1:
+                rationale: Part of the first base-runtime prototype.
+                ref: a52f5878e6df031497b70b156a43ea5ab2429b02
+            libtdb:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7c70b64d84d353206ecf6a00aaf2a37ad8dc4d33
+            libteam:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5738c2150b88a229f8453138c2eafc5e459a7c59
+            libtevent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 53b203d125b62bb8e622c7c7295813a73368562e
+            libthai:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94eb9c8cebe27123c1197ae694f9257cdc7ee5ad
+            libtheora:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9d69dbaa6aabe74d063e6710412b9d76ccce31a3
+            libtiff:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3f96a09397bb6fd6a61e4635ae50a92e9a4623c1
+            libtimidity:
+                rationale: Part of the first base-runtime prototype.
+                ref: 25e9e44d316b79529988a0b9917e7fec5ee57e08
+            libtirpc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6ce775f260cd4369471ce03d9a27e986d16bf21d
+            libtomcrypt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8f708d94edf5e69efd66f368f6302a58e8e2f9be
+            libtommath:
+                rationale: Part of the first base-runtime prototype.
+                ref: 55f9fab3cb8a39b666addd5200421742d72b2e19
+            libtool:
+                rationale: Part of the first base-runtime prototype.
+                ref: 95504dfbb10effb5c9e66bf89b8a45430ef32af9
+            libucil:
+                rationale: Part of the first base-runtime prototype.
+                ref: fefea8290a90b10100ec9d50d5afc01f8a47e02c
+            libunicap:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3c4c4540f35c8762c7a7a5b6cbe78470f390b86f
+            libuninameslist:
+                rationale: Part of the first base-runtime prototype.
+                ref: 538a73e10c9840b2f6e9c115307447cc499a4bac
+            libunistring:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7c5c8ba610df0b89e3defcef735bf8ddce6d7053
+            libunwind:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9e0a9246ef38b05d31100becf7f3eeccc3947a3b
+            libusb:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9550037548d478592a881da11ad9e23ca357c740
+            libusbmuxd:
+                rationale: Part of the first base-runtime prototype.
+                ref: 86499251f38e4faeca3e4bdec692b363c5fc4d18
+            libusbx:
+                rationale: Part of the first base-runtime prototype.
+                ref: 88c706d3668b0b8e847469125e7fa638d1f0fba0
+            libuser:
+                rationale: Part of the first base-runtime prototype.
+                ref: c47aa5a9a96bb1fbca50da415ed59ce86287c27f
+            libutempter:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6ac4eae053ab38ffba758bfdd4a7c28bcd906817
+            libuv:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6c4223b1cb4bdd88a038cd8d30870c71c9a62949
+            libva:
+                rationale: Part of the first base-runtime prototype.
+                ref: 39919df6e3967e8a2e8872ba7e60d6a6c4d1714e
+            libvdpau:
+                rationale: Part of the first base-runtime prototype.
+                ref: 43fb4d1974a0e38e8dcffd9da4736f638db56f64
+            libverto:
+                rationale: Part of the first base-runtime prototype.
+                ref: 587a6841d8eec700d4c41569dc3f9067594ce44b
+            libvirt:
+                rationale: Part of the first base-runtime prototype.
+                ref: fc2ebb76460613c7cfbfbe2a004ea6dfc05478b0
+            libvisual:
+                rationale: Part of the first base-runtime prototype.
+                ref: c4304082eaa4b39e926f71a0ad08268798bfd3a6
+            libvoikko:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1ed9ca79abb2ca58aaf6461893a5f7415aaa1596
+            libvorbis:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9694480ef377184632482cb1791e4dbd32a664e2
+            libvpx:
+                rationale: Part of the first base-runtime prototype.
+                ref: d239a4355a3136564f3d7db23d66c79723dccf98
+            libwacom:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9510827205229779b7e29860741a3a718c71a363
+            libwebp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1e1f101997cbdbf443bc49d5de09ad01d50055b8
+            libwmf:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0914b9077c6c2e27a6587e87afc1d58ba216800d
+            libwpd:
+                rationale: Part of the first base-runtime prototype.
+                ref: a17642e5563b6fb26b992f3e0cc5fb8b89dd3b29
+            libwpg:
+                rationale: Part of the first base-runtime prototype.
+                ref: 215aca698c4546ac6623273220011c65ec6098e7
+            libX11:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6a330925847b4c692de6dbc710991c8c38d016d6
+            libXau:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3dcf8e120f834639c3c5fc08073d5d0c1290a7ac
+            libXaw:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7a1184da67d42a60697968bef56959893510cd05
+            libxcb:
+                rationale: Part of the first base-runtime prototype.
+                ref: d9236f1b255ab2af15a931b2a1611e81dc69cb26
+            libXcomposite:
+                rationale: Part of the first base-runtime prototype.
+                ref: f2a45bc5f64a1ee1f824d71a97135775aed028e4
+            libXcursor:
+                rationale: Part of the first base-runtime prototype.
+                ref: b7a967f3f3d61b1313ed75addd4957a8ae3b7c3e
+            libXdamage:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2b97cd5cbc32f2042a79da92aaff1615007e8555
+            libXdmcp:
+                rationale: Part of the first base-runtime prototype.
+                ref: e862bbde62918f7fbf1422588518499d5ca6c4cd
+            libXevie:
+                rationale: Part of the first base-runtime prototype.
+                ref: d188c4b8d534bb001e5af6c8a171322fd7c3be59
+            libXext:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0bd38aa105ef81bc7b3e65143b6cbaad8a986bf5
+            libXfixes:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6a827feb92eaa35ad5909385d982d59f2f113558
+            libXfont2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 73251aca290a1858a2d957c36860b625bc5cd550
+            libXfont:
+                rationale: Part of the first base-runtime prototype.
+                ref: a26f207fe86f0b24c88305e0e30a60ee0f871bb6
+            libXft:
+                rationale: Part of the first base-runtime prototype.
+                ref: a52125d3c4902017c7fa0875aa768c5ef1f1b715
+            libXi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 51d3c5993f98faa9180a87fbe1347a2f6942f491
+            libXinerama:
+                rationale: Part of the first base-runtime prototype.
+                ref: 145330b1c7e75a23992d699f6258a924644c0dcc
+            libxkbcommon:
+                rationale: Part of the first base-runtime prototype.
+                ref: cdfa899b934914866fdc91a3af2622bace4b1419
+            libxkbfile:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9b021aa13b96070d55e3934256ca7d87fc91bd6a
+            libxml2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6054f5fed6d3a5200024df39ba0c12d759df2ab4
+            libxml++:
+                rationale: Part of the first base-runtime prototype.
+                ref: 37878f5458eb308f355f647ae01e1da6459a2a70
+            libXmu:
+                rationale: Part of the first base-runtime prototype.
+                ref: c7844b6d359a319ca6e3cf971a92c0823cb1e6e4
+            libXNVCtrl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 995410f8809efe8a16fdf521d4d4cecabeea9045
+            libXp:
+                rationale: Part of the first base-runtime prototype.
+                ref: b11c82558504d5d4d29084ae04c3decc8c8639f0
+            libXpm:
+                rationale: Part of the first base-runtime prototype.
+                ref: fc3475eddda7deefd5cc8f3214263546f7dfe718
+            libXrandr:
+                rationale: Part of the first base-runtime prototype.
+                ref: ae944cf1e4f41a46e207cca0b4e6741dac3640db
+            libXrender:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4036498b2b1db33552d672bf6d345a7ebff72d95
+            libXres:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0e5450c02baf4f4e123f677e3c8eac5f1e4cd05c
+            libXScrnSaver:
+                rationale: Part of the first base-runtime prototype.
+                ref: 66e9b4f0549a6b123ca1b5ddb2cfdaf5874d91c8
+            libxshmfence:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6972019c25524d6eb7ab725f9e7106a170b0b44d
+            libxslt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5d1cba6453afdd6f00a46c99c6cec275f2b8cf23
+            libXt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 728f8d21d607efc58ea2151231ea95a0b142eba6
+            libXtst:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5f749611880f21c2452f928fa9c71f4262c97e5e
+            libXv:
+                rationale: Part of the first base-runtime prototype.
+                ref: 687a0cd3646096c32b5e1a32550000258cb609bb
+            libXxf86dga:
+                rationale: Part of the first base-runtime prototype.
+                ref: 453e660eb25100ca2aec159e090511542353788b
+            libXxf86misc:
+                rationale: Part of the first base-runtime prototype.
+                ref: e5cf174463862308dbeb9422b8b5b4984ab2c58e
+            libXxf86vm:
+                rationale: Part of the first base-runtime prototype.
+                ref: f42ee6f501292f1fedb6f1b5849ece07d58966e9
+            libyaml:
+                rationale: Part of the first base-runtime prototype.
+                ref: 37b704866ec7ea0f66db0a81135ae7dfebf97a76
+            lightcouch:
+                rationale: Part of the first base-runtime prototype.
+                ref: 18fef5384e21234fa398807f1be2c4c751adf8a0
+            lilypond:
+                rationale: Part of the first base-runtime prototype.
+                ref: 166ec2801820762e6e7baf67826f2dafcd8d6cf3
+            linux-atm:
+                rationale: Part of the first base-runtime prototype.
+                ref: aaac1c68cfa5ae7fe861aa7b13a678eaf2b985f6
+            linuxconsoletools:
+                rationale: Part of the first base-runtime prototype.
+                ref: bb658a59285025a402ae598058d408edb410d1e3
+            linuxdoc-tools:
+                rationale: Part of the first base-runtime prototype.
+                ref: c861e2686801b0beeba9e95b09055f8a67a8e622
+            linux-firmware:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0bc84572c09b8c036bc581578aab3c8f78772685
+            liquibase:
+                rationale: Part of the first base-runtime prototype.
+                ref: 47db048942863222f201273774a63b10d67b3186
+            lirc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 716f0e5218036e279a8dabef6bbb4ea49770e535
+            lksctp-tools:
+                rationale: Part of the first base-runtime prototype.
+                ref: cbdf04d956f9275eb0581833fb13570ed64e0f6e
+            llvm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0c3be089606b485e1bcfe3a1d853ce888732513d
+            lm_sensors:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1f1bae2c8999c2df93dfdbc6c852cecc17b67228
+            lockdev:
+                rationale: Part of the first base-runtime prototype.
+                ref: ace43363866e11e9e14f1ff091e234248000ff7f
+            lodash:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8775b23c620118040f07cbdd1e94868fab30d84f
+            log4j12:
+                rationale: Part of the first base-runtime prototype.
+                ref: da33c36fc66d4ff64488c2b2668e96f31e817859
+            log4j:
+                rationale: Part of the first base-runtime prototype.
+                ref: f5fa40863146f7817facfe7faf4c3d6b2953b73b
+            log4j-jboss-logmanager:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5b7047c6a498f02b8b166dc64b9aecb822f6559a
+            logback:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7e48874557dc58fc49a2f05dd59e9b357e50adf7
+            logrotate:
+                rationale: Part of the first base-runtime prototype.
+                ref: b0ff9c33c75cea4d45c9da85b04ad855735747aa
+            lpg:
+                rationale: Part of the first base-runtime prototype.
+                ref: 043fee3d56bbdc6695d3b2f9178c2fb05427be76
+            lttng-ust:
+                rationale: Part of the first base-runtime prototype.
+                ref: 772e3be3c3d7bb3fade55b465a3f11694e14bc1e
+            lua:
+                rationale: Part of the first base-runtime prototype.
+                ref: 423087435dca32fcecee9d76f048f204c084d925
+            luajit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 969d554cd77f370ab29a387932222c418d591601
+            lua-lunit:
+                rationale: Part of the first base-runtime prototype.
+                ref: c4a8d011035b2311361d3a25c93cdedeb83626d4
+            lua-posix:
+                rationale: Part of the first base-runtime prototype.
+                ref: 827a31c0b2b6109d63173bce64ce5e9589784598
+            lucene3:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4c43bb0fc4abd4fd6b4f8e4837ae5a7e365d8caf
+            lucene4:
+                rationale: Part of the first base-runtime prototype.
+                ref: fc88ed2a7f6a07b786aa8906f3fbaa034f5272ec
+            lucene:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6d771c87dc66611576f9935a04cbbf9b28680663
+            lv2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9588acec3a0ed53a38e99ce66e7a0a14dfac613c
+            lvm2:
+                rationale: Part of the first base-runtime prototype.
+                ref: ef2f5a2deb52014553be805fd530c67fd1479aa3
+            lynx:
+                rationale: Part of the first base-runtime prototype.
+                ref: 219be74ae0a3af854555ea66041fe9f402075fb9
+            lyx:
+                rationale: Part of the first base-runtime prototype.
+                ref: 53bb39f957993fb3c4d86647505b23d821db65f5
+            lz4:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1517b8972be4544f246fde06e37de1ff4564dabb
+            lzip:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8327812accaae69d9f25a9bd941444d70bb64a06
+            lzo:
+                rationale: Part of the first base-runtime prototype.
+                ref: 633cc6d717414d91657b19a7a4b89affcb07a6da
+            m17n-db:
+                rationale: Part of the first base-runtime prototype.
+                ref: 310ba58acf42a5ea90d6eec4c431950d359ea943
+            m17n-lib:
+                rationale: Part of the first base-runtime prototype.
+                ref: c5f350df385eb59c61fe2afc5dea8af707b99be6
+            m2crypto:
+                rationale: Part of the first base-runtime prototype.
+                ref: b66be037eb36b434175f08301a6b7c17eb8b77c4
+            m4:
+                rationale: Part of the first base-runtime prototype.
+                ref: dc8b8038b81331d31ecefe7147dc18b1c9176e00
+            mailcap:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1f76e99415288e6498359e0e9ba0dd1d602a898c
+            mailx:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5da0b702e90c47632ba2425cef401abc7b0fc1bb
+            make:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3fc63a36eb10248737597a7cbedf621bf46fec6c
+            malaga:
+                rationale: Part of the first base-runtime prototype.
+                ref: 090919f1a9c5e559733b2cb6b4c9ccbb9838f623
+            malaga-suomi-voikko:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9dd7b1b943f6360664fe001f3d26f0ae215f1620
+            mallard-rng:
+                rationale: Part of the first base-runtime prototype.
+                ref: 76f2c992146be8c674bc2fe6114bfbe54aeef9ba
+            man2html:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1c9e8b0a7232eedcbb1630f366207e8b172e1346
+            man-db:
+                rationale: Part of the first base-runtime prototype.
+                ref: 98f13860c7089fe81942cf0cb1d702eba6c709bf
+            mariadb:
+                rationale: Part of the first base-runtime prototype.
+                ref: f02f0df623418a0f692b771196794871665eb517
+            maven2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 171ef93e90eeffeccaecb9122e7533d23a78ce31
+            maven:
+                rationale: Part of the first base-runtime prototype.
+                ref: 679f60f9f04697bd441a3f45c8d61d54657bafa6
+            maven-antrun-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9481c89997c0b8efb2fbbbf699f48ae35163ab51
+            maven-archiver:
+                rationale: Part of the first base-runtime prototype.
+                ref: bd9c53889eb9b0421d38d056d0f6900fc99f0199
+            maven-artifact-resolver:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4676665ba9b784a4450f7df06c3f8b8def524f34
+            maven-artifact-transfer:
+                rationale: Part of the first base-runtime prototype.
+                ref: aba4aab50f30e65d27c65c51fab416b48f7a2856
+            maven-assembly-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1b6a52cc3e9168272b74947df4039f756d62353d
+            maven-checkstyle-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 260bf560944f78b5f7ff039d2cdcac76fafcd71d
+            maven-clean-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2f58e3f4bf6cff49315bee32bd57a1ae55f72bef
+            maven-common-artifact-filters:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3411b576efa570f47e0534733da02bd6739bc977
+            maven-compiler-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: fa9eb2909c7c6e943a32971d25dcc2e10264cae8
+            maven-dependency-analyzer:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5e99aac17aa2aa56c25d842c2a4342ef610d359e
+            maven-dependency-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 987ec9a42e3a6dfee2e1ca6f8d7526ce2be33c3e
+            maven-dependency-tree:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4eb95e116dd8cae1a702f42008d4cfb514cf85c4
+            maven-deploy-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 95cc1e4aad28ec97e4536cafb9ac14db8b4c2cbb
+            maven-doxia:
+                rationale: Part of the first base-runtime prototype.
+                ref: f14834c3832cdf45d09be4fa489971e92c38c144
+            maven-doxia-sitetools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8046d4387e2b63ed6497ca1ad15f4bad99af3d74
+            maven-eclipse-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 43f1ffac24eb92e42d58dca3d0120776fc45bd31
+            maven-enforcer:
+                rationale: Part of the first base-runtime prototype.
+                ref: 54ffdf4db52f34dd2bddd40fae2495dbe11c783d
+            maven-file-management:
+                rationale: Part of the first base-runtime prototype.
+                ref: 46a0127a43545a5d3f6321b489ef138836dd5cd9
+            maven-filtering:
+                rationale: Part of the first base-runtime prototype.
+                ref: 67f235a9449c7aeab10f83101ce1ff8a05076ad8
+            maven-gpg-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9b89e75d979634824e4b7b22f9dbda34ecb1b6e5
+            maven-idea-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 66c0c5a40975f6237b396c0f443cfcac8f5291df
+            maven-injection-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: c3da2233e803b82812e30e068431e963f8c32adc
+            maven-install-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 41353134fe119db9a77b263e259d1cfd25861cce
+            maven-invoker:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4d93f55fae2e48b8a0b9e79ee47b3a773b580040
+            maven-invoker-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: a8a168e2476119cd96fed910cd30771900ff9b68
+            maven-jar-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: a2f85ea64b439264282b14bc68c39437acb20a98
+            maven-jarsigner-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 456798a5b1dfda22eac667be5111d51ba6fd7045
+            maven-javadoc-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 106bf31e0baa15585d47fbda20f58361762f0efe
+            maven-jaxb2-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0645dfc34d4fd01031f8598131ea67107920d98b
+            maven-jxr:
+                rationale: Part of the first base-runtime prototype.
+                ref: af5a3bd99826b4ce0af9b6c603567cd0c356c865
+            maven-license-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 028dc24242f52bc9104c55c8f7c1317b58685dea
+            maven-mapping:
+                rationale: Part of the first base-runtime prototype.
+                ref: fb873dd93656934038d108c056069970d4af73ab
+            maven-osgi:
+                rationale: Part of the first base-runtime prototype.
+                ref: b49b3b5fa9c168591428b1e463e9aadf262528e5
+            maven-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 38fac65b743738272044cca324f895a592721701
+            maven-plugin-build-helper:
+                rationale: Part of the first base-runtime prototype.
+                ref: fab2a056d24cec36222c59ba4ce4179b3e3dc407
+            maven-plugin-bundle:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7d5ec7e2a80d240af10d291de24bd061e1b621aa
+            maven-plugins-pom:
+                rationale: Part of the first base-runtime prototype.
+                ref: c815fb576ef0189894e64f0dffd523e3ea984583
+            maven-plugin-testing:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3fc689d4c63db8aaf8797dc5b828dfd8d4515bb0
+            maven-plugin-tools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 56bf83607ec915a0cab5d83029b879e4533e9f47
+            maven-pmd-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3208b35de6fb1f18490e21b3e6879882baf5ead3
+            maven-processor-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 994c606cf826e6d8952950cc14782c545ab5a119
+            maven-project-info-reports-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3e59801abfe50b97a53fab49ed57f1de243ae81e
+            maven-release:
+                rationale: Part of the first base-runtime prototype.
+                ref: b2934fab9abc9f221fa8af0f3b25e140a3f012a3
+            maven-remote-resources-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8d1252ccd867f71ccfbc44d2a9134c51b655c7eb
+            maven-reporting-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: b299cbe8b835876925f26e776d5ea36ce6fef77a
+            maven-reporting-exec:
+                rationale: Part of the first base-runtime prototype.
+                ref: b8e4bf77dab88ded9b972d975b37f73307d95cbb
+            maven-reporting-impl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7f5389edc9f2c45e3613074e6aa48e6a38be02fb
+            maven-repository-builder:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5c6602127d3df5c039155f5a882f9455b48523b4
+            maven-resources-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 963a66491acccdea27fdf71f228e4143487499ae
+            maven-scm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 25b1484f74dca9b2afa14fa108e6454225b98adc
+            maven-script-interpreter:
+                rationale: Part of the first base-runtime prototype.
+                ref: a7354e0e8dabc6fca73e51580d97700bda3856ca
+            maven-shade-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: a0205510cf141c22eb1c0cde548f8720351701dc
+            maven-shared:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6d7fb3d1bfc0d32b8ee17f8b05d3844df31c9db6
+            maven-shared-incremental:
+                rationale: Part of the first base-runtime prototype.
+                ref: 53cf8d28bf53d02bf99a658d355d0fa260a0ffb8
+            maven-shared-io:
+                rationale: Part of the first base-runtime prototype.
+                ref: d9bde82891f6162280499f1aa12339f9f4928c2d
+            maven-shared-jar:
+                rationale: Part of the first base-runtime prototype.
+                ref: 28f552b43317d50583f123498b56705dd3874ed2
+            maven-shared-jarsigner:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7f0e8df3981fb774b573dd8c1d22e488f8a39db5
+            maven-shared-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: fa784bd131be57489dc1b126a731ee9d780c6712
+            maven-site-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 45fec2bcaea8a05bd8d3cb058d14098e9ea3408e
+            maven-source-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 994686f4dc8dc5299105d89db9ec5902b663351f
+            maven-surefire:
+                rationale: Part of the first base-runtime prototype.
+                ref: b12f34181180e1982df637f5d8b82ba0f0efe5c5
+            maven-verifier:
+                rationale: Part of the first base-runtime prototype.
+                ref: 25611488711e8239dcc0eec1e96508595f0260b4
+            maven-verifier-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 46fbfa3539299bdd728d85ee33c3faf66e6d90aa
+            maven-wagon:
+                rationale: Part of the first base-runtime prototype.
+                ref: 009a833c42699848ee89601895c8be28bc878c3a
+            maven-war-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: a42284964d93ca85cc907394a0447b551e5964d6
+            mchange-commons:
+                rationale: Part of the first base-runtime prototype.
+                ref: c3359918209d6c3a69a46af4c7d72bb1480c60c8
+            mcpp:
+                rationale: Part of the first base-runtime prototype.
+                ref: ca2b2dd5c8e376c5f90beae97e7dbbf596986920
+            mdadm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5db3c6a31e7ffe3db25e3a3de3afe47698489f52
+            memcached:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1fcfb8cb72fb5a2009b6476e0871598bdf6aeabc
+            memoryfilesystem:
+                rationale: Part of the first base-runtime prototype.
+                ref: 72b464f1d85fac6dea1f87fd264a1f89b631b2cb
+            mercurial:
+                rationale: Part of the first base-runtime prototype.
+                ref: efef1b380f50ab9e50ef5877f503b4040df8a62b
+            mesa:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6651ada7db8654cfd23403e2f3542ea168919f11
+            mesa-demos:
+                rationale: Part of the first base-runtime prototype.
+                ref: c25635accdf574aec52883fae5aead170dd772bc
+            mesa-libGLU:
+                rationale: Part of the first base-runtime prototype.
+                ref: d1a505f749cb3fbea1ba89a3281a426c7cd394a0
+            metadata-extractor2:
+                rationale: Part of the first base-runtime prototype.
+                ref: a99fa813c4555067c0b90ce572c98bcb75aa4c42
+            metainf-services:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9e0d12d8296fe8b5383b2db2c20db93e2b750c0f
+            metrics:
+                rationale: Part of the first base-runtime prototype.
+                ref: bdfb4fd1dbf9314b7a19c75b5b69d21932167431
+            mftrace:
+                rationale: Part of the first base-runtime prototype.
+                ref: af9c0d1e803e450af9bbe7433ee969c9cfc000a1
+            mimepull:
+                rationale: Part of the first base-runtime prototype.
+                ref: 577c238d0ce0c6f97f0e8782df0c4f9ccf1ae9e0
+            mina-ftpserver:
+                rationale: Part of the first base-runtime prototype.
+                ref: f549b236c0dbc691fad6c4012ab79f37bf51f1f3
+            mingw-binutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6b73c72b7cce4f2c9916aa8fd7ba5a196de4080a
+            mingw-crt:
+                rationale: Part of the first base-runtime prototype.
+                ref: ba1785b40542422720ba1dbbb5144aeafb0681fc
+            mingw-filesystem:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7bb5a7f841c7a9dc4548ec523066455e424ca93b
+            mingw-gcc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 44681479b6276d7593dd9ef14ddab896c3420681
+            mingw-headers:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4eaf65f96203f03bbc92428ce7fcd87d2079ca93
+            mingw-winpthreads:
+                rationale: Part of the first base-runtime prototype.
+                ref: b307fed1ac6f75cd02846fcd496dea1a2971062e
+            miniz:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8e7205aefd70c075b69ae9f431b896222b1d0aab
+            minlog:
+                rationale: Part of the first base-runtime prototype.
+                ref: 67ed5dbcb864eba83d5f2a3359608fc04a17d139
+            mocha:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8c2789f4d18de0926220a85cb0e094ced7201923
+            mockito:
+                rationale: Part of the first base-runtime prototype.
+                ref: e15b1b8c60a37ec42b1a7bace0f9231dd946b363
+            modello:
+                rationale: Part of the first base-runtime prototype.
+                ref: 71db74e880b06acad7d4b80bf878a477d3064cf2
+            ModemManager:
+                rationale: Part of the first base-runtime prototype.
+                ref: b88ad3a72952ac7eec20b0b3d4fe2424b3ad6969
+            mojarra:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1168fb6cad1b8a227a8d003f87b7d843a01d5142
+            mojo-keytool:
+                rationale: Part of the first base-runtime prototype.
+                ref: d8ed2e4aa0a48795ffdb0a8e2a864ec898fc024e
+            mojo-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: b337053395e8ecf3dc364b6dce571727f6ea2de4
+            mokutil:
+                rationale: Part of the first base-runtime prototype.
+                ref: 91fec3ce6e902fbb59ce54de0864dc7a4eb348ac
+            mongo-java-driver:
+                rationale: Part of the first base-runtime prototype.
+                ref: c4fcc440836bce62189aa3f30b2a0755027b478a
+            mono:
+                rationale: Part of the first base-runtime prototype.
+                ref: a64664635935d65e795a4aae7eade170201cad86
+            morfologik-stemming:
+                rationale: Part of the first base-runtime prototype.
+                ref: c5f3f506526cff4fb958cae91337de320fdf32ff
+            mozilla-filesystem:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4172d1d5e8a88c7ed9dc773877327092c52754bd
+            mozjs17:
+                rationale: Part of the first base-runtime prototype.
+                ref: c101ddefd2e4760219f24565aa740a671bb5dcc8
+            mpfr:
+                rationale: Part of the first base-runtime prototype.
+                ref: cfd38587d76cf676f146c4d591359d72358f313b
+            mpich:
+                rationale: Part of the first base-runtime prototype.
+                ref: 305328091794f7a560939af337e0cceae1135b97
+            msv:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7aae89f84297666297013d30162de5fc56e8afd6
+            mtdev:
+                rationale: Part of the first base-runtime prototype.
+                ref: b87b8123e8df6cfb6d9cb6a33612300840f28fcf
+            mtools:
+                rationale: Part of the first base-runtime prototype.
+                ref: d7abd9a4eecc4e2ca21b38c423fde1d17267534f
+            multilib-rpm-config:
+                rationale: Part of the first base-runtime prototype.
+                ref: d44f6e2a6629ed3b6d49f51f9325380d27ae19b3
+            multithreadedtc:
+                rationale: Part of the first base-runtime prototype.
+                ref: eeae06ed7249ad6e83314af3ccc9b63311612023
+            multiverse:
+                rationale: Part of the first base-runtime prototype.
+                ref: c95af8246b13ac9c9421f3fe5a736c1f7b63a87a
+            munge:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3919c1199d90e82c1b9a148c1837daf55cbfb8bc
+            munge-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: bca5eca0592bcf9e01a7048c20bfc0a0e15bbe64
+            mustache-java:
+                rationale: Part of the first base-runtime prototype.
+                ref: d5365248bcf175bedb9de0518d15a02e35caba5b
+            mvel:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3fb1f191605ea130b4ce80440e032a3f741f4cb1
+            mxml:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3a88b4ee7ef248caaeceddd673c7c5ea4919ee52
+            mybatis:
+                rationale: Part of the first base-runtime prototype.
+                ref: 17c6d33e23e1a4cc89bc994886df5d449c9a35f9
+            mybatis-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: afdb20c0ba5f50231b977028b9d14a59099d99c3
+            mysql-connector-java:
+                rationale: Part of the first base-runtime prototype.
+                ref: 23626e0a5dcf71437266491066251683e7860c71
+            nailgun:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8528ab7414abb1d61e3e23de78f1a3377408a6aa
+            narayana:
+                rationale: Part of the first base-runtime prototype.
+                ref: 577881f3af5fd389c071a1968dcd0ea7059f1261
+            nas:
+                rationale: Part of the first base-runtime prototype.
+                ref: 423898f7d5f6a7b275cfb1e7b5a3095a50cbe9a4
+            nasm:
+                rationale: Part of the first base-runtime prototype.
+                ref: d0e0a3c141bc48493cb2de162c5aa7492329700d
+            native2ascii-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0c0bd2b4d3dfddf3c92e46737f4a26ddf940a3bd
+            native-platform:
+                rationale: Part of the first base-runtime prototype.
+                ref: 52199db11405884de833c153d9f0890be494a30f
+            ncompress:
+                rationale: Part of the first base-runtime prototype.
+                ref: 183266e0ac9f4bff65a987f1016411b9b69766d6
+            ncurses:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7273e821b3e590bc37090db7b9c29706b6f8b10b
+            nekohtml:
+                rationale: Part of the first base-runtime prototype.
+                ref: d71c32e220e961ef122c3dff8f2328cd8c9ef6a5
+            netcdf:
+                rationale: Part of the first base-runtime prototype.
+                ref: a37c838d1936aa41e928b783f09c0f2890461724
+            netcf:
+                rationale: Part of the first base-runtime prototype.
+                ref: b03c7153423194b19f547d4e30bfd9a4de33589c
+            netpbm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9ec28379f3b97ef8b8c3922919dcd29d70c93e7a
+            net-snmp:
+                rationale: Part of the first base-runtime prototype.
+                ref: d353462c74f183e7170f7cbe5c1ad6b0f5074940
+            nettle:
+                rationale: Part of the first base-runtime prototype.
+                ref: 86a8835aac7c2cf2e0e912ea867941a915583032
+            net-tools:
+                rationale: Part of the first base-runtime prototype.
+                ref: fe60060df23a86640697c145160cf15d4d44c149
+            netty:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2d63dcf3d90948c83430fe7f9fdebbf2959cdc4a
+            netty3:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3e7edaee9d7943ad487f1a5a0afbbe5b9bf4fd51
+            netty-tcnative:
+                rationale: Part of the first base-runtime prototype.
+                ref: b1dc85589e220fe4b84fe0192759cb31ef09876b
+            NetworkManager:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3a1a8315bc403ab3f8a6ffaea219fb2e18140f28
+            newt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0fd4137cb11128ec5a7107fccdbef2921a4bced6
+            neXtaw:
+                rationale: Part of the first base-runtime prototype.
+                ref: a2b7e60ddca3a3580c0a32d25030d2d6fd949d0a
+            nfs-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: c88ee7a9880e3b3deaf1d1a56789f0eb59b2d7b6
+            nghttp2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6f4f38d65797dc28db2e8876ead0f1446bb78337
+            nginx:
+                rationale: Part of the first base-runtime prototype.
+                ref: 23177a52db2755b5d9bbd81150ae1a168fdaf14b
+            ninja-build:
+                rationale: Part of the first base-runtime prototype.
+                ref: c52f1d350be31db91eda186e547f1d4d42d15083
+            nkf:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9831167210317b7353c8bb1b1a8289f7e38c7ad1
+            nmap:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8082f50a9c2f3c7df4995a9d0156d0c303d8f94d
+            nodejs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 063f7fefc5d9aed11a75b6b4c703c34002a1cd2a
+            nodejs-abbrev:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4aa13fb723f7e85c915a26afb4c68fb54934bbe7
+            nodejs-ansi-font:
+                rationale: Part of the first base-runtime prototype.
+                ref: 95c2c43060ed2408793918b2ea77a079e986c275
+            nodejs-ansi-regex:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9d8de9fc3f7f77d7e9db510d4ef60619647eb593
+            nodejs-ansi-styles:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3ee23d16627110b6c7edd065e3bcaa31fb59f08c
+            nodejs-argparse:
+                rationale: Part of the first base-runtime prototype.
+                ref: 65b73713d36b3a51729474576732247cbaed20a6
+            nodejs-array-differ:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7e462d320ac70fdda693462873127f3e4a70180f
+            nodejs-array-union:
+                rationale: Part of the first base-runtime prototype.
+                ref: c4bc572f74b6e1898614b055a68e09e93bc7899d
+            nodejs-array-uniq:
+                rationale: Part of the first base-runtime prototype.
+                ref: 61226f00a835b9c56ba62015970e3f0b3d911781
+            nodejs-arrify:
+                rationale: Part of the first base-runtime prototype.
+                ref: f0656814d38184dee539261da2dde53d37b506b9
+            nodejs-asap:
+                rationale: Part of the first base-runtime prototype.
+                ref: 51d7ae73690d2556d61435aad72c988c18691e0b
+            nodejs-assertion-error:
+                rationale: Part of the first base-runtime prototype.
+                ref: 64b3ca296ba32ea0908f39d6658c807638673495
+            nodejs-async:
+                rationale: Part of the first base-runtime prototype.
+                ref: 597f9ae05017ec93790ad35a966e862647c5588d
+            nodejs-balanced-match:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2f84b8a8966f0db93a11533203547446c126b497
+            nodejs-better-assert:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3b53bb2ad97a7f58f6e8dd1b423eeee7aeffb949
+            nodejs-bl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9547f9c2635817620a3c2fbec6c51979dcbe974b
+            nodejs-bluebird:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7a62457d5dba1523fbcbbd305734ca8895dd9b8c
+            nodejs-brace-expansion:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3b50419b774b06b11057679ebf7094b4ed68dea6
+            nodejs-buffer-equal:
+                rationale: Part of the first base-runtime prototype.
+                ref: 92d609a4329253509e503c1fb92f43c4cd4aea6d
+            nodejs-builtin-modules:
+                rationale: Part of the first base-runtime prototype.
+                ref: b0b90ea6556a33463d2d8df2aff731dd1b12bd70
+            nodejs-bunker:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5b81d2fd92fa088ab37bc76d81120f0e4373a5fe
+            nodejs-burrito:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8d042335d2924d4d541fd0bd55c96fdbd8e16606
+            nodejs-caller-callsite:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3f2218b11272f6b2e79232a8b9376e1e6ad1b95d
+            nodejs-caller-path:
+                rationale: Part of the first base-runtime prototype.
+                ref: f115cb1ded63b8a1f4140f88b7260fc311afffde
+            nodejs-callsite:
+                rationale: Part of the first base-runtime prototype.
+                ref: d5c5a8246489104ae0a0cc7ba84751db7d58e645
+            nodejs-callsites:
+                rationale: Part of the first base-runtime prototype.
+                ref: 16b192e751ac2595e0f51d82a11aee2b64232884
+            nodejs-chai:
+                rationale: Part of the first base-runtime prototype.
+                ref: ce75d72553acd589939aa95817f90e00cee9d736
+            nodejs-chalk:
+                rationale: Part of the first base-runtime prototype.
+                ref: cfc61db8bde38b69f08bf44197ed36ba3ab9c136
+            nodejs-character-parser:
+                rationale: Part of the first base-runtime prototype.
+                ref: a719c250a006f49c2b094d3c9c14921a56409019
+            nodejs-charm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 32c480b41664494536c2126e95ed59ffe0140df5
+            nodejs-cjson:
+                rationale: Part of the first base-runtime prototype.
+                ref: bf6d76db6f599f4ab7813017b3c31c84c0126f6f
+            nodejs-cli-color:
+                rationale: Part of the first base-runtime prototype.
+                ref: a6a8619487502907b53e1fc8e39d7d1a73495332
+            nodejs-closure-compiler:
+                rationale: Part of the first base-runtime prototype.
+                ref: 88207781f040c6ca4810243698e86f226fe94269
+            nodejs-colors:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6a2a0b90c72ec4e8d13fc7085b89b047e9cd2d1a
+            nodejs-commander:
+                rationale: Part of the first base-runtime prototype.
+                ref: 38e083241712861c97124fcaa73fa481d3968cf0
+            nodejs-commonmark:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4f76273e8c26975458e6f4576bb9e7cf65246f44
+            nodejs-concat-map:
+                rationale: Part of the first base-runtime prototype.
+                ref: 80a21de85a3f07116d395ca13684a054d9234ff7
+            nodejs-concat-stream:
+                rationale: Part of the first base-runtime prototype.
+                ref: 724668adb725e7833401200bdedc7f8715d4c333
+            nodejs-console-dot-log:
+                rationale: Part of the first base-runtime prototype.
+                ref: 93d6a612e896ec0e6f8d4f0fb31a55f7473c5e13
+            nodejs-constantinople:
+                rationale: Part of the first base-runtime prototype.
+                ref: d1fa4fe1abd2aff70f28f3f77fc58b7f74dd2b99
+            nodejs-core-util-is:
+                rationale: Part of the first base-runtime prototype.
+                ref: efc0860da9c95d0e2e5713455ef22baefeca2b4c
+            nodejs-css:
+                rationale: Part of the first base-runtime prototype.
+                ref: f62cadf6baf702bd1e23da4579d05ec8ad42d904
+            nodejs-css-parse:
+                rationale: Part of the first base-runtime prototype.
+                ref: 528a45f8d77c43fe555f4d02812099a355f712f9
+            nodejs-css-stringify:
+                rationale: Part of the first base-runtime prototype.
+                ref: 05891f4972f80ed8860d24273621415493e24e7b
+            nodejs-dateformat:
+                rationale: Part of the first base-runtime prototype.
+                ref: 425435b993334039d5b705afd5e01e60cbc35113
+            nodejs-d:
+                rationale: Part of the first base-runtime prototype.
+                ref: d5212c4c02543e9163d50fce30609e807e0583a7
+            nodejs-debug:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1c499e671c1ef3e0305c6982f64028b717e27bac
+            nodejs-deep-eql:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8fd16183678b8146c47e96c5cecae334e71421bd
+            nodejs-deep-equal:
+                rationale: Part of the first base-runtime prototype.
+                ref: 557c94ed6b0b06ca77e39d5c6ab3affbcfea6fa5
+            nodejs-defence:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2d3ebc4ac6ab2a5ee85ee5bc2294ce009d467270
+            nodejs-defence-cli:
+                rationale: Part of the first base-runtime prototype.
+                ref: c58be4ce8a9ec8f24abf5c985a956bde7237955f
+            nodejs-defined:
+                rationale: Part of the first base-runtime prototype.
+                ref: 52803c0533c162a25c1b627cadcc331675e31c3d
+            nodejs-define-properties:
+                rationale: Part of the first base-runtime prototype.
+                ref: 35ddc8efbb113b084b4132b0112a720d02916863
+            nodejs-diff:
+                rationale: Part of the first base-runtime prototype.
+                ref: 29e0db34f0e5a75a9208ee7bca4c187465f1a111
+            nodejs-difflet:
+                rationale: Part of the first base-runtime prototype.
+                ref: f86bdda4757b9a083fbbdc2f3ebfb3c0aeeb1a4c
+            nodejs-difflib:
+                rationale: Part of the first base-runtime prototype.
+                ref: e1b411272cafb8552fb7ea43e0d67f5209d94bd5
+            nodejs-docopt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 47010c442022124d5d55aaf4878d4d97e22cd1e3
+            nodejs-dreamopt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5b21ae3d32be673ee845b55f024e617d3f57d442
+            nodejs-duplexer:
+                rationale: Part of the first base-runtime prototype.
+                ref: c1a9e1ee680f38f40336356b52edd4ab8877e4e7
+            nodejs-ebnf-parser:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6a82dc52a70e8f51e614ec795263f877a6a0df30
+            nodejs-ejs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1b3e026248619da23a795e5fbcbeeef1a53d5069
+            nodejs-emojione:
+                rationale: Part of the first base-runtime prototype.
+                ref: 80a4ec539aed05ccdd2df2dcb14efd4ba34c2e11
+            nodejs-entities:
+                rationale: Part of the first base-runtime prototype.
+                ref: d579bc3ee3e56d44af33d0ecb0c3f04c804ee346
+            nodejs-es5-ext:
+                rationale: Part of the first base-runtime prototype.
+                ref: d641a290a8ecb9b1250eb96c3cdcabc316daed51
+            nodejs-es6-iterator:
+                rationale: Part of the first base-runtime prototype.
+                ref: f12a055add558cb2c27ba15b1a1c3b042c2f0322
+            nodejs-es6-symbol:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5a20c95a2984a9caa147732f523c6e0ea35be68d
+            nodejs-es6-weak-map:
+                rationale: Part of the first base-runtime prototype.
+                ref: 41a7dbc15c4cb27102009c05cae8e12e222dab99
+            nodejs-es-abstract:
+                rationale: Part of the first base-runtime prototype.
+                ref: dffc13fa04c61ebabd74b0f3efe637c1fce2f5e1
+            nodejs-escape-string-regexp:
+                rationale: Part of the first base-runtime prototype.
+                ref: ac940f6003702b7df355a2635b456b69c162da26
+            nodejs-escodegen:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7d998320b505f4299f57970312a4a92e2e44dd82
+            nodejs-esprima:
+                rationale: Part of the first base-runtime prototype.
+                ref: d8376eb096e5c9b2ce7ea6704e94e2d9d97da687
+            nodejs-es-to-primitive:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8048db4507fa22acb3d30b566776848789f901ca
+            nodejs-estraverse:
+                rationale: Part of the first base-runtime prototype.
+                ref: a91a1b3ce77a8d44ca5f59742738122e9211c521
+            nodejs-esutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: a1d81681f728501b73251a223c2944310b15a7cc
+            nodejs-eventemitter2:
+                rationale: Part of the first base-runtime prototype.
+                ref: ff1f247bb2bc8c5bd945733fa75287ccdb827158
+            nodejs-event-emitter:
+                rationale: Part of the first base-runtime prototype.
+                ref: 661bde81758462aaeb1d008fb484b33581e70514
+            nodejs-events-to-array:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3dc747b05d179ae9fd8a78e7e556bf380a938c33
+            nodejs-exit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94b8ce7a51df39742d251dc2e4d00c1b5e4affce
+            nodejs-expect-dot-js:
+                rationale: Part of the first base-runtime prototype.
+                ref: db408da9eeaeff070d1b5dfb2a5ef1e1282b3ca2
+            nodejs-faye-websocket:
+                rationale: Part of the first base-runtime prototype.
+                ref: b1616e14c91fa8e627f9045295e9a26bb17ee76a
+            nodejs-figures:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5ba90b70e19c6c643c1954a53e0f43cdf33cc6a2
+            nodejs-fill-keys:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2de0326f82c812caa3cf46295107860d3d3f4aec
+            nodejs-findup-sync:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1c64c0b0970ab06819e3ad998fda46338a70b097
+            nodejs-foreach:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3b6bd94a25ff7334537d43d97dd31314db26c10f
+            nodejs-formatio:
+                rationale: Part of the first base-runtime prototype.
+                ref: 50c39f8f1fee248f557aa6175f58285ed8846eb8
+            nodejs-from:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4b9dfb37deaa5cd5610defa7aa4b3cca257653c5
+            nodejs-function-bind:
+                rationale: Part of the first base-runtime prototype.
+                ref: b9833ce7b04675a1fb562e37e08b4a1ebe7029cb
+            nodejs-gaze:
+                rationale: Part of the first base-runtime prototype.
+                ref: bd7c69a2b9a4f2444392df2d112fbcfbee2a5a09
+            nodejs-getobject:
+                rationale: Part of the first base-runtime prototype.
+                ref: e40e09e3f5ffb01bfa571b8ef0ea3219d13bf1fe
+            nodejs-github-url-from-git:
+                rationale: Part of the first base-runtime prototype.
+                ref: cf35a1602210afd18f63a4ea5704156e84c47d60
+            nodejs-glob:
+                rationale: Part of the first base-runtime prototype.
+                ref: 17862c8b604e1b892bce2ff05d4d604b9892383c
+            nodejs-globule:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8d291c932a1efcc51dd651e2d490e6a8cb40e251
+            nodejs-graceful-fs:
+                rationale: Part of the first base-runtime prototype.
+                ref: c5e922d5bb1f281ef0530b708abb0e85d2f4f355
+            nodejs-graceful-readlink:
+                rationale: Part of the first base-runtime prototype.
+                ref: a9b57f3db8ee41bc2fb28a46acef70da628841df
+            nodejs-growl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 928952f60709920fd4e150df6461dbb182bef04f
+            nodejs-grunt-cli:
+                rationale: Part of the first base-runtime prototype.
+                ref: f6d68afcbe456c8bf1767c1fb768e2cff8edd0d2
+            nodejs-grunt-contrib-clean:
+                rationale: Part of the first base-runtime prototype.
+                ref: aa4942cac176d13a112b61a850fc71e3900cc7aa
+            nodejs-grunt-contrib-internal:
+                rationale: Part of the first base-runtime prototype.
+                ref: 57d0948f4323a419df9c84d1fdc91e775b391e89
+            nodejs-grunt-contrib-nodeunit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 33285bdc39867895333038366fc756ae416170f2
+            nodejs-grunt-contrib-uglify:
+                rationale: Part of the first base-runtime prototype.
+                ref: 183e240f5dfb67f0568c56273e5a4bb5cf74b079
+            nodejs-grunt-contrib-watch:
+                rationale: Part of the first base-runtime prototype.
+                ref: 454d64f4b73a88c6fe09c91cfcb53118741e2a21
+            nodejs-grunt:
+                rationale: Part of the first base-runtime prototype.
+                ref: f2862b390d642105a235ed89d5e506dc37cec98e
+            nodejs-grunt-known-options:
+                rationale: Part of the first base-runtime prototype.
+                ref: f38f673717ffd9a1d9ca7d47254777c6977e4cc4
+            nodejs-grunt-legacy-log:
+                rationale: Part of the first base-runtime prototype.
+                ref: a4027ec9e84a8c2990765d3f4367cf1edf021b54
+            nodejs-grunt-legacy-log-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: f8f154446ec273aa521858cdfea9957e149020b0
+            nodejs-grunt-legacy-util:
+                rationale: Part of the first base-runtime prototype.
+                ref: ab1a53c5edf4d8e4cc46615e5d4e7c60faaded56
+            nodejs-gzip-size:
+                rationale: Part of the first base-runtime prototype.
+                ref: f6743217125835d848114d4adbc0b205729fa059
+            nodejs-has:
+                rationale: Part of the first base-runtime prototype.
+                ref: a31bc52fcd986cba8d7cfbed60ddeb1b37e65b85
+            nodejs-has-ansi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8640a9a8ef9e5130ab33f689340240b8627cb2c4
+            nodejs-has-color:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5a585cc11f5f00dccad20349a4ba91b0598029a5
+            nodejs-hash_file:
+                rationale: Part of the first base-runtime prototype.
+                ref: b4fba9c5cd20a7a00b2635f8e9e867ae6442460f
+            nodejs-hashish:
+                rationale: Part of the first base-runtime prototype.
+                ref: b3e8584e7cf47ab19f47fe5408cde47458f5c36a
+            nodejs-heap:
+                rationale: Part of the first base-runtime prototype.
+                ref: f2b49b348c40ae46363a39aaec776737bcbd1671
+            nodejs-hooker:
+                rationale: Part of the first base-runtime prototype.
+                ref: b1b546382554a9609f800b4de35cf47a0c6d895d
+            nodejs-hosted-git-info:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0feb543d2a473ce26e114365880e074456e14dc3
+            nodejs-iconv-lite:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2e1de42166f850b974016888e82d419da3242692
+            nodejs-inflight:
+                rationale: Part of the first base-runtime prototype.
+                ref: d18c78efcfb72d0cf541274966cb24622a1781f7
+            nodejs-inherits1:
+                rationale: Part of the first base-runtime prototype.
+                ref: ca6ee0e3a8fcd9419abaad4e3c25ed6c5a85986e
+            nodejs-inherits:
+                rationale: Part of the first base-runtime prototype.
+                ref: 238e0d077b5b5b4da509082e3bef3ddb268eff3b
+            nodejs-is:
+                rationale: Part of the first base-runtime prototype.
+                ref: 93f07ad7cfdeb400104b1504f241eb5bfa5697ac
+            nodejs-is-absolute:
+                rationale: Part of the first base-runtime prototype.
+                ref: ddff19486abddcdca9784faa0a6584a3613cb2ec
+            nodejs-isarray:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1b1da9b07eabb91a2d079f10146db189463df1a5
+            nodejs-is-builtin-module:
+                rationale: Part of the first base-runtime prototype.
+                ref: c16052bff7cbab28c868940e39be35e64e600294
+            nodejs-is-callable:
+                rationale: Part of the first base-runtime prototype.
+                ref: db588319046d159056716f2a23b0130000b81fc0
+            nodejs-is-date-object:
+                rationale: Part of the first base-runtime prototype.
+                ref: a493cda43608ee9247c5150da4634c4c0ba178ae
+            nodejs-isexe:
+                rationale: Part of the first base-runtime prototype.
+                ref: fbdd384f1627358c0815f1fb3c0f268ed4da3b29
+            nodejs-is-object:
+                rationale: Part of the first base-runtime prototype.
+                ref: aed1e86cf2a84396eba095dcd59e4e71eb33d811
+            nodejs-is-regex:
+                rationale: Part of the first base-runtime prototype.
+                ref: 71300e63abe4a701469cb121dd7681f2ac2f2d88
+            nodejs-is-relative:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3c4540d2d880de646ca7b725d6a24baba1fce986
+            nodejs-is-symbol:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6f7f49e8bd67cc476fe877938540cb6fe8c026e7
+            nodejs-is-unc-path:
+                rationale: Part of the first base-runtime prototype.
+                ref: 88144711cf77c32597e1445f36de44a5b21b851a
+            nodejs-is-windows:
+                rationale: Part of the first base-runtime prototype.
+                ref: 77b9f57bb26a704a723bbd724bd7a01d3f506e3d
+            nodejs-jade:
+                rationale: Part of the first base-runtime prototype.
+                ref: c98aed7707aa1a9fd97fd7b82f4e8c2e01f3f539
+            nodejs-jison:
+                rationale: Part of the first base-runtime prototype.
+                ref: b075ce71ed05b830ba258505b9f653cf2805a14e
+            nodejs-jison-lex:
+                rationale: Part of the first base-runtime prototype.
+                ref: f1ec10893ecb07a907754ebdd33bce4d976ac906
+            nodejs-jju:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4e42ecfc7b8d4e5d1221db3c4b1f87d0fb644608
+            nodejs-json-diff:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5e76f6c73cb0c4c0161c5570f626db5adc3f00a3
+            nodejs-jsonify:
+                rationale: Part of the first base-runtime prototype.
+                ref: d21857296e2c8833ce332f625a4b65f9271f432c
+            nodejs-json-parse-helpfulerror:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9f99f50c8aac9c95b3f8f9dcae085d58d6ab5e76
+            nodejs-jsonselect:
+                rationale: Part of the first base-runtime prototype.
+                ref: 90af8e0b05d8c1b35b4eb82279cef2d7c23752de
+            nodejs-js-yaml:
+                rationale: Part of the first base-runtime prototype.
+                ref: 80457bc5e8a90e3295f1742e185858ff59aaa202
+            nodejs-lex-parser:
+                rationale: Part of the first base-runtime prototype.
+                ref: 92305c4f06898947421076e7c972949bba58f90f
+            nodejs-load-grunt-tasks:
+                rationale: Part of the first base-runtime prototype.
+                ref: aab0c6b0675191901202ed8215c4db93107da3c6
+            nodejs-lolex:
+                rationale: Part of the first base-runtime prototype.
+                ref: ade674e5f44f7ae8114c2f6632ac6a0c89b758c5
+            nodejs-lru-queue:
+                rationale: Part of the first base-runtime prototype.
+                ref: 77090f1f62b4f60ff329118e137bfbb5bfbfe551
+            nodejs-make-arrow-function:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4d281edc3d073f13bb1026ff290a1a628314f09d
+            nodejs-make-generator-function:
+                rationale: Part of the first base-runtime prototype.
+                ref: e28ebf71daa7773c170bd41520daf0e37028bccc
+            nodejs-maxmin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 649fb0ea5a50865fa50ea15d4e6695645ed600aa
+            nodejs-mdurl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 73aa58088224e814e2b2dfb8ec268ede2d9958be
+            nodejs-memoizee:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4ed63e514b3c5fa19f4afe918d9d241c0f0574c3
+            nodejs-merge-descriptors:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1edc2a5b5fab733294fed75eeffac32d024928c1
+            nodejs-minimatch:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4d78e79362fc430bc6f05b29cb443d8e601c398f
+            nodejs-minimist:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4ffc4d4319efbeaadb78f97d3790139ad13674d1
+            nodejs-mkdirp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 810876255b78f2d11a33ec334d6669445b451a81
+            nodejs-mock-fs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 501cb6da1985964b6d85f2fa4eef6e6d2a19177c
+            nodejs-module-not-found-error:
+                rationale: Part of the first base-runtime prototype.
+                ref: ce4a53d857e15631070874de9ce67a20aedc4efa
+            nodejs-monocle:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5a8479c88c8cbcc9aa5d4cd5b469187600479ab2
+            nodejs-ms:
+                rationale: Part of the first base-runtime prototype.
+                ref: c26297cf766ca2cf3f08ec94ff093049e27e6acd
+            nodejs-multimatch:
+                rationale: Part of the first base-runtime prototype.
+                ref: 37415193e9a84b0d5b609135933aa48138164d7c
+            nodejs-next-tick:
+                rationale: Part of the first base-runtime prototype.
+                ref: b98a08d1a4f1ee151ed6c9371ebdc7b4e634b027
+            nodejs-nomnom:
+                rationale: Part of the first base-runtime prototype.
+                ref: b75c01263f14cd3df14833994e392c5e7fd5b159
+            nodejs-nopt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 53f55583beb3051bd50e1bc3b8f8e07595b093fc
+            nodejs-noptify:
+                rationale: Part of the first base-runtime prototype.
+                ref: 470eafc2c6c4a5a593fb9d89a70ee464136511d3
+            nodejs-normalize-package-data:
+                rationale: Part of the first base-runtime prototype.
+                ref: 163fef6d5935b5d0c24371f74a6dd25b5ecec92a
+            nodejs-number-is-nan:
+                rationale: Part of the first base-runtime prototype.
+                ref: b3025235b80de3ba95ac2b3a965d2f7c6a2d08bb
+            nodejs-object-assign:
+                rationale: Part of the first base-runtime prototype.
+                ref: 270be7833a5b769672bd5ed7dccf3a4cf1f5acf5
+            nodejs-object-inspect:
+                rationale: Part of the first base-runtime prototype.
+                ref: df7472ec27556723efffbe8363b68a53935994c4
+            nodejs-object-is:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0a2c74ae0c0a58d0ab7a228392d529b78ce9bf8a
+            nodejs-object-keys:
+                rationale: Part of the first base-runtime prototype.
+                ref: fe495e247e09c5ca284e5c518769c3a80455f31f
+            nodejs-once:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2ebf412e626be7570b832bb296313f90e0c3e981
+            nodejs-optimist:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0c809020bd56574d9d0caae40cc1a78e86d73d6b
+            nodejs-package:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9fa81077e8f1b12be409753c8f35c45ba70745f6
+            nodejs-packaging:
+                rationale: Part of the first base-runtime prototype.
+                ref: 697d52f2612c8c30352e3aa0863ba7db6de24e86
+            nodejs-paperboy:
+                rationale: Part of the first base-runtime prototype.
+                ref: ae0ab89413ff4b74640cc364523ec2110712134f
+            nodejs-path-is-absolute:
+                rationale: Part of the first base-runtime prototype.
+                ref: b564d40a6dc1aa5707b37006bf8a55e61b86a91d
+            nodejs-pretty-bytes:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8fc55aa7637b5745bb610fc7a0ec86a97615f6b9
+            nodejs-process-nextick-args:
+                rationale: Part of the first base-runtime prototype.
+                ref: 836fbe1cf04be310dc67e220739e66ca21a185ff
+            nodejs-promise:
+                rationale: Part of the first base-runtime prototype.
+                ref: 19dc233677613394d7d522b37586a5f1edfa29de
+            nodejs-proxyquire:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94fe81b08209494b0f4914d725a409d9313d0475
+            nodejs-qs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 79de04f375ba81d2a7e9fe92b7808a437e31638a
+            nodejs-readable-stream:
+                rationale: Part of the first base-runtime prototype.
+                ref: 92a7531a43f948ea017a45057c97705da1759081
+            nodejs-readdirp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7c2566e190263a63c0962a5ce7228b2c3ab0c9df
+            nodejs-read-package-json:
+                rationale: Part of the first base-runtime prototype.
+                ref: a7ba3c963efe012f7c9d31122e193773785d02ac
+            nodejs-replace-require-self:
+                rationale: Part of the first base-runtime prototype.
+                ref: c1f31255a911e5734f980f40add1c623c4327108
+            nodejs-requirejs:
+                rationale: Part of the first base-runtime prototype.
+                ref: f1ceddc65ceb67dbb3346fafdf38bbe9a919ecad
+            nodejs-require-uncached:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3a9968e2f691c53dfbb111a8beda5c70b5b687bb
+            nodejs-resolve:
+                rationale: Part of the first base-runtime prototype.
+                ref: 46762f599fe53b1dcaad46fa839e697342d9d359
+            nodejs-resolve-from:
+                rationale: Part of the first base-runtime prototype.
+                ref: 09904fa268bf1819dae10ad74f9afbe4c5dc83c9
+            nodejs-resumer:
+                rationale: Part of the first base-runtime prototype.
+                ref: b123415fcd22fa02677474057b58c06ba359abfb
+            nodejs-rewire:
+                rationale: Part of the first base-runtime prototype.
+                ref: bd5bf52ebc57a448afc98541df895f73ce803ff3
+            nodejs-rimraf:
+                rationale: Part of the first base-runtime prototype.
+                ref: 48015e0ebacccf23202dd0abc8db23fff26405ae
+            nodejs-runforcover:
+                rationale: Part of the first base-runtime prototype.
+                ref: 00760f65d884ee71e9bd069c38037141f1cca0cd
+            nodejs-samsam:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0ae485f91858ed26de6c6964c182e84332f209a8
+            nodejs-semver:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1b68b9fec8d04662de45c51fcaa8352adb2e134d
+            nodejs-set-immediate-shim:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9cd383bdf22befea3efbdb43b7e0a09f2afb6a12
+            nodejs-shelljs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7a434bbacac413672eebbe5c125519d1d8d6571a
+            nodejs-should:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2ad2e560675426370093a7faacf1ecc6b4b850d3
+            nodejs-should-equal:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4da2c33fd9cc7ee222103b4edb82798919a9a5fd
+            nodejs-should-format:
+                rationale: Part of the first base-runtime prototype.
+                ref: 79ce6b51d06b82dd82f6f0b1a8ba1102b260b6da
+            nodejs-should-type:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6b918997baa8e8d8582896250d7029d53abb580e
+            nodejs-simple-assert:
+                rationale: Part of the first base-runtime prototype.
+                ref: 718a04c0d5ce5d309b5a1bdaf20c52c828dc8d0e
+            nodejs-sinon:
+                rationale: Part of the first base-runtime prototype.
+                ref: a7557651c8e64873549b99c543f0fe1bfe1239c4
+            nodejs-slide:
+                rationale: Part of the first base-runtime prototype.
+                ref: 904fa6782b4d6441e6bf4900a321895437afe93f
+            nodejs-source-map:
+                rationale: Part of the first base-runtime prototype.
+                ref: 54f987029e93c36986bc67281bc8f3cb5482cf68
+            nodejs-spdx-correct:
+                rationale: Part of the first base-runtime prototype.
+                ref: 59af731d8f0fba015306ead8bd0c546f3d56ba7d
+            nodejs-spdx-exceptions:
+                rationale: Part of the first base-runtime prototype.
+                ref: 40d94dc1e6dba07dbc6fd7f05bfc82d911b1d0e7
+            nodejs-spdx-expression-parse:
+                rationale: Part of the first base-runtime prototype.
+                ref: afab4f9e811a3540008e1f248d46db98ae34a20a
+            nodejs-spdx-license-ids:
+                rationale: Part of the first base-runtime prototype.
+                ref: 282982b0b5c7f3c5a07468ada0ee0576cac92dd8
+            nodejs-sprintf-js:
+                rationale: Part of the first base-runtime prototype.
+                ref: c5bbf140debea1fb7f7ab94c513c9dcd518b6540
+            nodejs-stream-replace:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1eed0b9e58324067aad659055646aa4243eefb62
+            nodejs-string:
+                rationale: Part of the first base-runtime prototype.
+                ref: 86a7377464bbfdc7e8959ed3eb2a6c2131b8ac9d
+            nodejs-string_decoder:
+                rationale: Part of the first base-runtime prototype.
+                ref: e7eebd8c4cb88662ea60972daae7a74bf637672e
+            nodejs-string-dot-prototype-dot-repeat:
+                rationale: Part of the first base-runtime prototype.
+                ref: a425f84eee85c1c08308155edb359ef6045dd3f5
+            nodejs-string-dot-prototype-dot-trim:
+                rationale: Part of the first base-runtime prototype.
+                ref: 876c1bd80a9d44738c0862b7cb4f74f70f5866cb
+            nodejs-strip-ansi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8431779f7de5517852957cbf705a7b0c3a84bf23
+            nodejs-supports-color:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6e57e0f4fefddc72e920d45f1010c0e8f06dd0be
+            nodejs-tap:
+                rationale: Part of the first base-runtime prototype.
+                ref: 56a346e5cf6e84411a488a154d3b617ebe49353b
+            nodejs-tape:
+                rationale: Part of the first base-runtime prototype.
+                ref: d6810aec41e3e1b3013e09d85e69679af87476f0
+            nodejs-tap-parser:
+                rationale: Part of the first base-runtime prototype.
+                ref: cdf3d7e2d20498026b57b42e7052a6c46e3e4152
+            nodejs-temporary:
+                rationale: Part of the first base-runtime prototype.
+                ref: a407562c259ef9422abd1c7c31d448e0809a43da
+            nodejs-test:
+                rationale: Part of the first base-runtime prototype.
+                ref: dbb76ffa1d408d85c06f8b0cd13d2f76f9d7575a
+            nodejs-through2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 28e5564eaa2f62bb77382679478b6d11059b403e
+            nodejs-through:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7f29ea5df781f9e56312402330d962c6e4ae5c0b
+            nodejs-timers-ext:
+                rationale: Part of the first base-runtime prototype.
+                ref: 02b149e6b466a5cf4d6356a93e319ac5f5605838
+            nodejs-tiny-lr-fork:
+                rationale: Part of the first base-runtime prototype.
+                ref: f377c57c59cdf55079a88052a0c4e7e66eda8f15
+            nodejs-transformers:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9d7ed461b014d9e0fcbdcb2477533b614f8da7c3
+            nodejs-traverse:
+                rationale: Part of the first base-runtime prototype.
+                ref: 36adf1cffa44cd7143f32204ed962f710294a814
+            nodejs-type-detect:
+                rationale: Part of the first base-runtime prototype.
+                ref: 748ae0744f3e4847556aa338c5317d24436f2272
+            nodejs-uglify-to-browserify:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8bf1d7ee27f88c3766def7ae42616b2a879f4205
+            nodejs-unc-path-regex:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5057e1fcd99be4837e324167b4de22f9039a008f
+            nodejs-underscore:
+                rationale: Part of the first base-runtime prototype.
+                ref: 03aa4dc2318faf247821585558552c2294118277
+            nodejs-underscore-dot-string:
+                rationale: Part of the first base-runtime prototype.
+                ref: ce31f511baaa7adb56e9b576d1b6c8684ea758ca
+            nodejs-uri-path:
+                rationale: Part of the first base-runtime prototype.
+                ref: b5ba8f59c7b2ada2a443d02f940ae92f8d9b2ba2
+            nodejs-util:
+                rationale: Part of the first base-runtime prototype.
+                ref: 77fd8778467b1cfe63bc15f7c6c08e4f4ca69bed
+            nodejs-util-deprecate:
+                rationale: Part of the first base-runtime prototype.
+                ref: 91b4fb1e2e856268ce94d6c57476d275527251d2
+            nodejs-validate-npm-package-license:
+                rationale: Part of the first base-runtime prototype.
+                ref: 86b24871ec2ccb97a42b8bdd0f60c0ecb53a02a5
+            nodejs-websocket-driver:
+                rationale: Part of the first base-runtime prototype.
+                ref: 166d9720355389abed0b1dc3bb3c4bf371539b24
+            nodejs-which:
+                rationale: Part of the first base-runtime prototype.
+                ref: d886829fd336d503bb6a36178367c87d60584db4
+            nodejs-window-size:
+                rationale: Part of the first base-runtime prototype.
+                ref: d8cfa370ae988ad3f9ed4f56551fd881d9ae38de
+            nodejs-with:
+                rationale: Part of the first base-runtime prototype.
+                ref: cc1f49e098d29789773a5d0b6770765f536259eb
+            nodejs-wordwrap:
+                rationale: Part of the first base-runtime prototype.
+                ref: f5537927f1e37b506aea6203975891d1c32502bb
+            nodejs-wrappy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 90b38624d6a74769198dab598033f604a8321fad
+            nodejs-xtend:
+                rationale: Part of the first base-runtime prototype.
+                ref: 42b4aa639eadd04d092dd4b3a4e177058d62f88a
+            nodejs-yamlish:
+                rationale: Part of the first base-runtime prototype.
+                ref: 493b345e7708d42a94967a047f0ee137cb94c4b9
+            nodejs-yargs:
+                rationale: Part of the first base-runtime prototype.
+                ref: a492be27a2a1770cf71c4068eea5845d97421750
+            nodeunit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 038918a5fd43e75d611ffe7ddbf587568e7574c5
+            noggit:
+                rationale: Part of the first base-runtime prototype.
+                ref: ac585c0c8824618025e3bb80379bbf2bb4ede278
+            npth:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2957622f9a5f74142eff0cd258a3b2115876bf18
+            nspr:
+                rationale: Part of the first base-runtime prototype.
+                ref: b5b30000aedcfa9cbcaf43b6c83324595f261373
+            nss:
+                rationale: Part of the first base-runtime prototype.
+                ref: 26f0f90d8b5e2dd7297a8f1546a46b2aa6b7e422
+            nss-pem:
+                rationale: Part of the first base-runtime prototype.
+                ref: e8c7d9a7a04449fa8383eb5fa18efb3bee2e51c5
+            nss-softokn:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7f431131037736bf2f7921748d273f5b73f18545
+            nss-util:
+                rationale: Part of the first base-runtime prototype.
+                ref: c83de9cc088022bba3f21e51bb158911c1312ef8
+            nss_wrapper:
+                rationale: Part of the first base-runtime prototype.
+                ref: 861148b0112dcf478acb59c241d1d256142ad730
+            ntfs-3g:
+                rationale: Part of the first base-runtime prototype.
+                ref: f53f66f9c837652615f4814159cf8be793601e46
+            numactl:
+                rationale: Part of the first base-runtime prototype.
+                ref: bcca29d2351882248524971a06b8792e93a7726d
+            numad:
+                rationale: Part of the first base-runtime prototype.
+                ref: fcaaa61d492cf677cb5c7351091f2fd09f4127dd
+            numpy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9051c9126aea2429994e6e6e01abd6b9614afc68
+            objectweb-asm3:
+                rationale: Part of the first base-runtime prototype.
+                ref: f59bffb35b7fb2f1112cd66090c4bc1f82a729c4
+            objectweb-asm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6a890e90737a8afa975b986c1f85a6d33e4cfb3e
+            objectweb-pom:
+                rationale: Part of the first base-runtime prototype.
+                ref: 164f00df4cf36001bb4c1a75e3da330479055299
+            objenesis:
+                rationale: Part of the first base-runtime prototype.
+                ref: 34161bf0e1349abd0543c2ca39ffeb3eebdc96fb
+            ocaml:
+                rationale: Part of the first base-runtime prototype.
+                ref: 496d4e4eafb670e14a7f5605991b61ad0de894ea
+            ocaml-camlp4:
+                rationale: Part of the first base-runtime prototype.
+                ref: 30d3f99385a02df797780fcad6956dc19d3624f7
+            ocaml-findlib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1b40710ea079295130e7effca39b1f568655bed4
+            ocaml-srpm-macros:
+                rationale: Part of the first base-runtime prototype.
+                ref: 325f0a18c50848bf61df6cfd75e80d2ead294114
+            octave:
+                rationale: Part of the first base-runtime prototype.
+                ref: 771edb219759928ae0694076f851a82d0a06133e
+            ogdi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 834c6942c7d861904cd3ab8512ce22fb7782b0d9
+            oniguruma:
+                rationale: Part of the first base-runtime prototype.
+                ref: c6ce3ed3ebf82deb32c038e057fa5c30e9a1a8a2
+            openal-soft:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9e5bf767ccb275d85417dd6a04590276941d3934
+            openblas:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4ca7446f5364d73ca3b8ab6c0e7e4ff7d9d2ea7f
+            opencl-filesystem:
+                rationale: Part of the first base-runtime prototype.
+                ref: 82feaf2c6f21d6d1b329ca9c8c404d7163c7b4e6
+            opencl-headers:
+                rationale: Part of the first base-runtime prototype.
+                ref: a4ea17525aa5561104a4358c786a40a9bf45510e
+            opencv:
+                rationale: Part of the first base-runtime prototype.
+                ref: e8cb9f1050c7559efe452532f89d3a84aada0a6f
+            OpenEXR:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4384e6dfd0c0922e23f2ade8bd0abd35e6a8a381
+            openjade:
+                rationale: Part of the first base-runtime prototype.
+                ref: f358a4eb8445fd397234d69d5192dfcaeaa5ac7b
+            openjpa:
+                rationale: Part of the first base-runtime prototype.
+                ref: a5066e7704a36c89ecc0e360d3deb374980784da
+            openjpeg2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9ca9e1b52e41ff79ca403e635fae0c4dec650886
+            openjpeg:
+                rationale: Part of the first base-runtime prototype.
+                ref: f07680caecc351cbe83561d65be86e01ab3d8c2c
+            openldap:
+                rationale: Part of the first base-runtime prototype.
+                ref: 31ea2073c92a39b1362f011799d4a7515518aa62
+            openmpi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 30cc030f4c393e960c60433beaff6a04c012df26
+            opennlp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0b87b540f8dbf9f62d274a7a84b4914425dfb307
+            opensc:
+                rationale: Part of the first base-runtime prototype.
+                ref: c4620785505dfd2a027c3d13aac9424965b42b5c
+            opensm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6a59ba193d2bc24adb0e2fb90074727f5ac23c84
+            opensp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9df60f18d6a47ce468a8ab9091b04385fc9e396c
+            openssh:
+                rationale: Part of the first base-runtime prototype.
+                ref: d924bc689233619f83343dfafd11dce55d5c474c
+            openssl:
+                rationale: Part of the first base-runtime prototype.
+                ref: e8261d1b72dbce2c0d27287704b99b84e53eca6b
+            openwebbeans:
+                rationale: Part of the first base-runtime prototype.
+                ref: c015d81d9ef020b673c394429757d45a8efc6504
+            openwsman:
+                rationale: Part of the first base-runtime prototype.
+                ref: f6475234567005ef83b8a8e0dffc40cbf818db13
+            options:
+                rationale: Part of the first base-runtime prototype.
+                ref: b0725a6a69102f85d43134c43df96415cdc103e9
+            optipng:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7c17ef59c0c4f8a3fb28b29babc80b7738c480bd
+            opus:
+                rationale: Part of the first base-runtime prototype.
+                ref: f6d7267e46930abd4e44355ba1db453a5fbb4377
+            ORBit2:
+                rationale: Part of the first base-runtime prototype.
+                ref: fc80f8b6e26736133c93bb15d87beaf27ecd746e
+            orc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 04107a876938430a9b32d512c93f16a73e8b795d
+            osgi-annotation:
+                rationale: Part of the first base-runtime prototype.
+                ref: 81d1bd45ae399150c4537243b708d500050435ab
+            os-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 54f7c4026559bd59ad9a3a664e6b944629d3ad26
+            os-prober:
+                rationale: Part of the first base-runtime prototype.
+                ref: c210816b8b0aadd7bbcfee9459202ccdcd19bf6f
+            p11-kit:
+                rationale: Part of the first base-runtime prototype.
+                ref: f1d174a2794cd0f9c5c969a9aa1e313db4fb9d5c
+            p7zip:
+                rationale: Part of the first base-runtime prototype.
+                ref: 43d1d572b06d855198e3e143be6866a3fa6c0a6a
+            pacemaker:
+                rationale: Part of the first base-runtime prototype.
+                ref: fc2ebb76460613c7cfbfbe2a004ea6dfc05478b0
+            pam:
+                rationale: Part of the first base-runtime prototype.
+                ref: 26153ac92dac511944f869f8962052361c064d11
+            pango:
+                rationale: Part of the first base-runtime prototype.
+                ref: a6e3f780e5e25f82deed97b7f06a7b94c3bb546b
+            pangomm:
+                rationale: Part of the first base-runtime prototype.
+                ref: a185e5a7aeb93b4da12533b4734b5b4fe1d13c25
+            pangox-compat:
+                rationale: Part of the first base-runtime prototype.
+                ref: f241fd0dc292d3c8f4c2a57a5cfb066fd1472ba0
+            papi:
+                rationale: Part of the first base-runtime prototype.
+                ref: a721c8757318dd153d54bb5cc02dbe359747be34
+            paranamer:
+                rationale: Part of the first base-runtime prototype.
+                ref: 19eb35d725064bf5137e9a07c6750a3763df774e
+            parboiled:
+                rationale: Part of the first base-runtime prototype.
+                ref: bb6dd09880a4ac9c766d3116909a7157caee2037
+            parted:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7e779bb3478ea3f15e4d5cbde8f72548e71d898c
+            passwd:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4438090a3f8e84becc0b88fd47fe20253ce82580
+            patch:
+                rationale: Part of the first base-runtime prototype.
+                ref: a39fb6b6e630fd259d5a067e43f29b6396915437
+            patchutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 937c0b800012600e418a13ab79c00315f087f295
+            pax-logging:
+                rationale: Part of the first base-runtime prototype.
+                ref: bef2fccd5dd4fe2fc62864d0eb1f31ac076fbf6f
+            pcfi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2fbd2006cdade30fe61446de9e9b7703b6601a49
+            pciutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5f449e759e228ca947ca61614e1ab5dd65267bd3
+            pcre2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3cab1f40be8b8283aa2e3b2c1cb19cde3b2ecb86
+            pcre:
+                rationale: Part of the first base-runtime prototype.
+                ref: acfd08086a3048e5fc23e607c095e2a960a0fe69
+            pcsc-lite:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0a2e4dbaff216e9ea56ef0927e4101b446fd318e
+            pcsc-lite-ccid:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3dd6dd40125c5c958629ebca6ad28dafddb19b15
+            pdfbox:
+                rationale: Part of the first base-runtime prototype.
+                ref: e02be4d2749289a98b27469bc3abbba4d4c94dc0
+            pdf-renderer:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6a407c050e9f198f3020543a4ab85c294eacb4e3
+            pegdown:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7bbcc94151c1521cad5fafe49714910410f9ade2
+            perl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8ed967feee5fb1144ab8c3a91766310c9356917e
+            perl-accessors:
+                rationale: Part of the first base-runtime prototype.
+                ref: 39067054b47b0f51fd96f22c6215398ab8f475c0
+            perl-Algorithm-C3:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7678cb45c7c05c71930389e29fd33c331f48930b
+            perl-Algorithm-Dependency:
+                rationale: Part of the first base-runtime prototype.
+                ref: da6da0c8cb38537108981f0ba7c54cc6896a14be
+            perl-Algorithm-Diff:
+                rationale: Part of the first base-runtime prototype.
+                ref: d289fe5f306d899b3e5eb73272b0eb62edc2e615
+            perl-aliased:
+                rationale: Part of the first base-runtime prototype.
+                ref: 99b0cef14f720ed41b6cc14d43c155ede5081273
+            perl-AnyEvent:
+                rationale: Part of the first base-runtime prototype.
+                ref: a443b3a63cc46f409d66bf8573f0e14e5afd9b1b
+            perl-AnyEvent-AIO:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8fb85a42426f99f966c0c4463d8cddddbf25807d
+            perl-AnyEvent-BDB:
+                rationale: Part of the first base-runtime prototype.
+                ref: db04a54e32f6c8d04b9df8962f00f97daaa71506
+            perl-Any-Moose:
+                rationale: Part of the first base-runtime prototype.
+                ref: b8a3b528657439bcbe7159233a214e4461ddf408
+            perl-Any-URI-Escape:
+                rationale: Part of the first base-runtime prototype.
+                ref: 09d09c634a506b954e73c1d376fd31fe900a5089
+            perl-AppConfig:
+                rationale: Part of the first base-runtime prototype.
+                ref: bbf1a349d6eee8a1e24138999f100bb7460f0d8e
+            perl-App-FatPacker:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6279e8fc356f16c2a09c278648b4e47605b8f99b
+            perl-Archive-Any-Lite:
+                rationale: Part of the first base-runtime prototype.
+                ref: e84898288939bc1b4541e79bc787e09f1baf5903
+            perl-Archive-Extract:
+                rationale: Part of the first base-runtime prototype.
+                ref: 507b257d6b90430e28cc6b058cf43bca32e1d292
+            perl-Archive-Tar:
+                rationale: Part of the first base-runtime prototype.
+                ref: 13c7a8fe7693f6b2f0eb5f934bccc0cf1b5c44f6
+            perl-Archive-Zip:
+                rationale: Part of the first base-runtime prototype.
+                ref: b64552c4d878106d4a2a7f1613c32441916ff44b
+            perl-Array-Diff:
+                rationale: Part of the first base-runtime prototype.
+                ref: 01ccd466ab39d7ce5b36794855cf8cd8521e144d
+            perl-autobox:
+                rationale: Part of the first base-runtime prototype.
+                ref: cd053fb7178c467c4985b4853adfca4292f51e8f
+            perl-autodie:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1fe0d61767b940541ebc13f07d459be7b75b2db5
+            perl-bareword-filehandles:
+                rationale: Part of the first base-runtime prototype.
+                ref: 76ddef9af21138337ef79db46fb0a2b400c60ebc
+            perl-B-Compiling:
+                rationale: Part of the first base-runtime prototype.
+                ref: b2ea7c85241faa9b786a43913c769effaf708f5d
+            perl-BDB:
+                rationale: Part of the first base-runtime prototype.
+                ref: 606e126c6a89cc1f779c2ab944115503e84c6e1b
+            perl-B-Hooks-EndOfScope:
+                rationale: Part of the first base-runtime prototype.
+                ref: 65559c4537e984dcffd1934c4e133b8c04d33640
+            perl-B-Hooks-OP-Check:
+                rationale: Part of the first base-runtime prototype.
+                ref: 68deae4b35caff40224e998512277048b35971e7
+            perl-Bit-Vector:
+                rationale: Part of the first base-runtime prototype.
+                ref: 71ed0e80350e780589a79d96734a4d5110e60327
+            perl-B-Keywords:
+                rationale: Part of the first base-runtime prototype.
+                ref: 75bef22487d3f5f2070d8b6865c65fe7b91654c4
+            perl-BSD-Resource:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3ffb3bd91f6bb7c1e6eb3c41c6cd5246917a847b
+            perl-Business-ISBN:
+                rationale: Part of the first base-runtime prototype.
+                ref: bf21dcd25fbaa80f26840026c9db83c49db9b27e
+            perl-Business-ISBN-Data:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9a61b5b8714f0e6441a1b8ae7003c1cafb8a9e1c
+            perl-B-Utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: db837ecfe15c455abb90098c9b4148f496fece12
+            perl-Canary-Stability:
+                rationale: Part of the first base-runtime prototype.
+                ref: 710ec007d90bce50681c8033bfba81c94364af64
+            perl-Capture-Tiny:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5213907b7b56c7583947d14e7b4e3f48ba889a27
+            perl-Carp-Clan:
+                rationale: Part of the first base-runtime prototype.
+                ref: cc4f501c5d8ddb191ad1f0e4bc1daea85a9767c7
+            perl-Carp:
+                rationale: Part of the first base-runtime prototype.
+                ref: df7ef84fdcb25b2f54846881599722b87b1347b8
+            perl-CBOR-XS:
+                rationale: Part of the first base-runtime prototype.
+                ref: be3e049981370f7ce5c41c13d6167ee1f05e49c6
+            perl-CGI:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7f408b71e67429f3af71d453e02a7f6bd7640ae8
+            perl-Class-Accessor-Chained:
+                rationale: Part of the first base-runtime prototype.
+                ref: 144edf7d0a89bf39495aa50f9379d4da296aed73
+            perl-Class-Accessor:
+                rationale: Part of the first base-runtime prototype.
+                ref: e3cad10f167583bac280a095f83099c1badee15d
+            perl-Class-Accessor-Grouped:
+                rationale: Part of the first base-runtime prototype.
+                ref: 082d498edb6bc720311a4b72891d51eb7242acf3
+            perl-Class-Autouse:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7746b99c5d5b0abbf146b35d0e020dbdeefb4788
+            perl-Class-C3-Componentised:
+                rationale: Part of the first base-runtime prototype.
+                ref: 47b3ac2cb866efdbd6ceb2797f8b5b68588e0814
+            perl-Class-C3:
+                rationale: Part of the first base-runtime prototype.
+                ref: faf645d989e38eb7d0ca215a6588384a514a6c77
+            perl-Class-Data-Inheritable:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5487837da968c332ff9265e2b12c48917d778044
+            perl-Class-DBI:
+                rationale: Part of the first base-runtime prototype.
+                ref: 14ce67991b0eebed108d5a3ef674cd7934b80b54
+            perl-Class-DBI-Plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 86cce03e3a7dc6cb5685d936135870aed06f007c
+            perl-Class-DBI-Plugin-DeepAbstractSearch:
+                rationale: Part of the first base-runtime prototype.
+                ref: 788f42a9db96082406814ecf7277fa4a0c603726
+            perl-Class-Factory-Util:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1e10bbede33c66d37cfaa1cf673f4f266fef628c
+            perl-Class-Inspector:
+                rationale: Part of the first base-runtime prototype.
+                ref: e9f6a7c165bb765c19a06461583d093906257091
+            perl-Class-ISA:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5a3cfb43b1a740450c8838d5297380a961a558ab
+            perl-Class-Iterator:
+                rationale: Part of the first base-runtime prototype.
+                ref: 952cb776a616f457f2372c65ecf378646a77b757
+            perl-Class-Load:
+                rationale: Part of the first base-runtime prototype.
+                ref: ee7f56b8268d61609d5085320756ae51648a1a9c
+            perl-Class-Load-XS:
+                rationale: Part of the first base-runtime prototype.
+                ref: fbe2fa06bdd869350585928612134fb34ef0f262
+            perl-Class-Method-Modifiers:
+                rationale: Part of the first base-runtime prototype.
+                ref: 229fb273d28116be7f8db253d3e2440af5da2766
+            perl-Class-Singleton:
+                rationale: Part of the first base-runtime prototype.
+                ref: a22c872be10ab651bf2753f4a07c7390f7dab2f2
+            perl-Class-Tiny:
+                rationale: Part of the first base-runtime prototype.
+                ref: b48645e1ff40f15ae7b147cea4cef1259668c695
+            perl-Class-Trigger:
+                rationale: Part of the first base-runtime prototype.
+                ref: 918535578842eaa3399f6eded3b4e311c13610a1
+            perl-Class-Unload:
+                rationale: Part of the first base-runtime prototype.
+                ref: e8d6ee1d66a9ff87de722d3f4197df6afaff798a
+            perl-Class-XSAccessor:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9c68103d3f6cec95c3d558fe6c9a57d71356b758
+            perl-Clone:
+                rationale: Part of the first base-runtime prototype.
+                ref: 26a2f8333b664748c80aed3af433b8e37b70cd32
+            perl-common-sense:
+                rationale: Part of the first base-runtime prototype.
+                ref: aced0821ab90a3cf4535b4b75e9589fd59bff0c6
+            perl-Compress-Bzip2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8a9d3dc425161f0e33359754c826533a61755ac1
+            perl-Compress-LZF:
+                rationale: Part of the first base-runtime prototype.
+                ref: 011f49cf6213289508e5403b5627f21227bb056e
+            perl-Compress-Raw-Bzip2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 20dfd7b5a6f4f1e7decb38f33c2b3be64aa40304
+            perl-Compress-Raw-Zlib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 684f6dd6a0e206f1b4223b3a758400006f3ee9e0
+            perl-Config-Any:
+                rationale: Part of the first base-runtime prototype.
+                ref: 942934cb199b141efda769f1f8b90516a3307aeb
+            perl-Config-General:
+                rationale: Part of the first base-runtime prototype.
+                ref: 112f4220501373b19bdef48bed18df1011a1bfef
+            perl-Config-Tiny:
+                rationale: Part of the first base-runtime prototype.
+                ref: bfdd6308f5cfcf6a2e6f1bec2354054935ecda44
+            perl-constant:
+                rationale: Part of the first base-runtime prototype.
+                ref: b4aa543ad481a5e5c74b4ce50a2ae8b35b7446b7
+            perl-constant-boolean:
+                rationale: Part of the first base-runtime prototype.
+                ref: bb4dbb339d4d4d9ed5247b45cfa3a2c0491e4d51
+            perl-constant-defer:
+                rationale: Part of the first base-runtime prototype.
+                ref: 07c0816971dce72ddb604eb3442fdf20feeeba30
+            perl-Const-Fast:
+                rationale: Part of the first base-runtime prototype.
+                ref: d7a86cd959c6a36e240869e383f77d0704d49838
+            perl-Context-Preserve:
+                rationale: Part of the first base-runtime prototype.
+                ref: 14a0e656f6799e9e63f9334f0f17b2e10e7b7b90
+            perl-Convert-Bencode:
+                rationale: Part of the first base-runtime prototype.
+                ref: d96bb92d2a633bbe485aa37b47699abd7595f9c3
+            perl-Coro:
+                rationale: Part of the first base-runtime prototype.
+                ref: b6bee1ffc487949e81413b50d60d96f1f211fdd2
+            perl-Coro-Multicore:
+                rationale: Part of the first base-runtime prototype.
+                ref: 24e33ab14c7fd030aa29c87f1961a705c46b4f64
+            perl-CPAN:
+                rationale: Part of the first base-runtime prototype.
+                ref: 02cb764604dd3972d694dd008396ece0ea25ae47
+            perl-CPAN-Changes:
+                rationale: Part of the first base-runtime prototype.
+                ref: 85d03768766b6c758b5ca85ed60d033156be0666
+            perl-CPAN-DistnameInfo:
+                rationale: Part of the first base-runtime prototype.
+                ref: ee7de18155209587c8400305432e9639c2a828df
+            perl-Cpanel-JSON-XS:
+                rationale: Part of the first base-runtime prototype.
+                ref: 66f88a4a476b70dcd5bb796b544926573bd35c9c
+            perl-CPAN-Meta:
+                rationale: Part of the first base-runtime prototype.
+                ref: 27f0e6750e5e5fc8c60b6485f50292773bb4b08c
+            perl-CPAN-Meta-Check:
+                rationale: Part of the first base-runtime prototype.
+                ref: 592c9445fa737a76dc4e9cc6357d242f4ea3f889
+            perl-CPAN-Meta-Requirements:
+                rationale: Part of the first base-runtime prototype.
+                ref: 882228aaf5412ce0903f4405e61bf6eecbf8d7f4
+            perl-CPAN-Meta-YAML:
+                rationale: Part of the first base-runtime prototype.
+                ref: 707d503f03007e22964c9721efa4758f7521aaa7
+            perl-CPANPLUS:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7a167efef83ba07ebe1ce1fbd5bbb0b96f9af8f9
+            perl-criticism:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1221aac8b0374e72d1d3d1056b24df54f0a654aa
+            perl-Crypt-RC4:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7b9e51d64b9107ffe8b0c04f7bdf572a57338fa4
+            perl-Crypt-PasswdMD5:
+                rationale: Part of the first base-runtime prototype.
+                ref: c02306201e1df1c5dc859e427c263948c4f4c65a
+            perl-Curses:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7b434368c3fb0a2e472227eb49bb06d7bf43ca6c
+            perl-Cwd-Guard:
+                rationale: Part of the first base-runtime prototype.
+                ref: 62003c396cbc102a3eefd597503291fcd1ed81d8
+            perl-Data-Dump:
+                rationale: Part of the first base-runtime prototype.
+                ref: e62dbf2896578034ba070a045390259f61dd277a
+            perl-Data-Dumper:
+                rationale: Part of the first base-runtime prototype.
+                ref: 01499c2b7c69a76184768b3dc9ba8efcc4c84a0e
+            perl-Data-Dumper-Concise:
+                rationale: Part of the first base-runtime prototype.
+                ref: 588460e5461636bb35c939d05e2a8a580dea451a
+            perl-Data-GUID:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3f72a540620a9ac603343ba4fffbd7d06d19fd8f
+            perl-Data-OptList:
+                rationale: Part of the first base-runtime prototype.
+                ref: c9cdf07231890d2097c68580fb4587f90c34551e
+            perl-Data-Page:
+                rationale: Part of the first base-runtime prototype.
+                ref: 680d9097301186384983ecb2f70bad3d7736824a
+            perl-Data-Perl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 60e4d959b7c72d802e4aadebdb43cc34a69aab2a
+            perl-Data-Section:
+                rationale: Part of the first base-runtime prototype.
+                ref: b6405902e46e73d0ccfb09fb71de1d7dd5d162ba
+            perl-Data-Section-Simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: 09f92088ee7be638abff6ad7ee5acfadb84264c4
+            perl-Data-UUID:
+                rationale: Part of the first base-runtime prototype.
+                ref: 572e17a7401574006f76866b2349146554f0c6cf
+            perl-Data-Visitor:
+                rationale: Part of the first base-runtime prototype.
+                ref: b9305d40d7bad35bbb5fb8748f5b136a53adb532
+            perl-Date-Calc:
+                rationale: Part of the first base-runtime prototype.
+                ref: b7b464b9f649d4d89d98a24ee36dac66f2e7b9a3
+            perl-Date-ISO8601:
+                rationale: Part of the first base-runtime prototype.
+                ref: bcecf70e39aa878b173136f1ca91e9b90d0fd54a
+            perl-Date-Manip:
+                rationale: Part of the first base-runtime prototype.
+                ref: 699e2126e85b13cf6a4850d79d3a8ca5f3e83956
+            perl-Date-Simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: 95d30c4c1e7cd872e1dee39ff755f110d7398a2d
+            perl-DateTime:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6e2e37678253df6f17a202ed542e14712ced06c7
+            perl-DateTime-Calendar-Mayan:
+                rationale: Part of the first base-runtime prototype.
+                ref: 62b7d7aac7b66ed8bc815f77f9605070b997442b
+            perl-DateTime-Format-Builder:
+                rationale: Part of the first base-runtime prototype.
+                ref: f802f6e0e460e036e177f6ef5a2cf76ac03cb5fb
+            perl-DateTime-Format-HTTP:
+                rationale: Part of the first base-runtime prototype.
+                ref: 55e8a05c8e66cb8e0f65bcad77890bfcd3c2c50e
+            perl-DateTime-Format-IBeat:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9daf8a01297ccdd0b8c81fb4c25c548def245cc1
+            perl-DateTime-Format-Mail:
+                rationale: Part of the first base-runtime prototype.
+                ref: 22e548d942ccb4c67f44549302f1493b188669ef
+            perl-DateTime-Format-MySQL:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1388773cc2f1217ceb436026669b72413787a166
+            perl-DateTime-Format-Pg:
+                rationale: Part of the first base-runtime prototype.
+                ref: 58f17279945b297390b1d8448b8b122fca5cfded
+            perl-DateTime-Format-SQLite:
+                rationale: Part of the first base-runtime prototype.
+                ref: 225584c982bf824909d45b5dda05d9da85a01a4e
+            perl-DateTime-Format-Strptime:
+                rationale: Part of the first base-runtime prototype.
+                ref: 52083bb584653ee179645f3a0651e7d9654bd704
+            perl-DateTime-Locale:
+                rationale: Part of the first base-runtime prototype.
+                ref: 36ff753902a949cea835fed0b5051cc57dec4511
+            perl-DateTime-TimeZone:
+                rationale: Part of the first base-runtime prototype.
+                ref: 164135c8dfd65812dcfa49ca3775ca34b0c238af
+            perl-DateTime-TimeZone-SystemV:
+                rationale: Part of the first base-runtime prototype.
+                ref: eb34e836e3cbbebf412785f5d6f37b519abba15a
+            perl-DateTime-TimeZone-Tzfile:
+                rationale: Part of the first base-runtime prototype.
+                ref: adc588f185c62147bf2b6dbf6f976025cc0d29a3
+            perl-DBD-CSV:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6918372e9eb11dffc8b750a46d5f6c724831c89d
+            perl-DBD-Pg:
+                rationale: Part of the first base-runtime prototype.
+                ref: bb4310787a81194da65f010cff6656a682656e37
+            perl-DBD-SQLite:
+                rationale: Part of the first base-runtime prototype.
+                ref: fa2e3bb8c5600aeb88e4b185b52a2ef0f0511543
+            perl-DB_File:
+                rationale: Part of the first base-runtime prototype.
+                ref: c752653a31f21c3930277bf7945772f2384cb61c
+            perl-DBI:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6eb834147d9a83d76158f4522c3d5b7d3b9d0bd2
+            perl-DBIx-Class:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8a615c40e200406b985715a32564fa0a30e33dc3
+            perl-DBIx-ContextualFetch:
+                rationale: Part of the first base-runtime prototype.
+                ref: 07446a37b106a9f07c9f3b9b8441fdf84554c739
+            perl-DBIx-Simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: beb2ea05d98f91b2723e1a187a9e9b880e565e60
+            perl-DBIx-XHTML_Table:
+                rationale: Part of the first base-runtime prototype.
+                ref: 73308a25aeb767c5794e1931ad8a2b81bee2e21b
+            perl-DBM-Deep:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1ccae0402f2aa99e72573ab6914ad94f84a9e35b
+            perl-Declare-Constraints-Simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0aefdab0569e56a5778f0658cadc6323ffa55fae
+            perl-Devel-ArgNames:
+                rationale: Part of the first base-runtime prototype.
+                ref: c950f6030ab52b1bf15a4f99127c79534ecc422e
+            perl-Devel-CallChecker:
+                rationale: Part of the first base-runtime prototype.
+                ref: 24275935b7b137f48916900a9cba2295c380aef5
+            perl-Devel-Caller:
+                rationale: Part of the first base-runtime prototype.
+                ref: 774d3eda3a2ae78b5affad9abbcd0056deae493c
+            perl-Devel-CallParser:
+                rationale: Part of the first base-runtime prototype.
+                ref: f1b3052d854d27f406861785658fd40c215fdc97
+            perl-Devel-CheckBin:
+                rationale: Part of the first base-runtime prototype.
+                ref: f270157db189bc93a94e43c747bed5769bc1f495
+            perl-Devel-CheckCompiler:
+                rationale: Part of the first base-runtime prototype.
+                ref: 819b40b6c2c679f1c845b4b786f4593567831218
+            perl-Devel-CheckLib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 79a9bbcff708b6f51db9cb40afd4400160191868
+            perl-Devel-Cycle:
+                rationale: Part of the first base-runtime prototype.
+                ref: c86d54ba164e6926b2b3a03799aa10ba00767383
+            perl-Devel-Declare:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4b8d4efa745e4ba694b1ba0acbdad8e773479704
+            perl-Devel-EnforceEncapsulation:
+                rationale: Part of the first base-runtime prototype.
+                ref: 00582514ef3a2683e62208f386cccebb9dbeb791
+            perl-Devel-FindPerl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 09c848dc9e4bdf6ff4f866ac5c1a713aa205f11c
+            perl-Devel-GlobalDestruction:
+                rationale: Part of the first base-runtime prototype.
+                ref: 74ab14ddf754a40e737c661ea894f0180096dc24
+            perl-Devel-Hide:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3385eb6a33505694bccf841a33b686f093bf77b4
+            perl-Devel-Leak:
+                rationale: Part of the first base-runtime prototype.
+                ref: b57e4e0eebae67ca65196be95d5afc1da91f8049
+            perl-Devel-LexAlias:
+                rationale: Part of the first base-runtime prototype.
+                ref: e1f95514cc120de6d7c85f2fea4cc445a341e9b0
+            perl-Devel-OverloadInfo:
+                rationale: Part of the first base-runtime prototype.
+                ref: d8d7ae187422fff197af140089e6210e91c791a0
+            perl-Devel-PartialDump:
+                rationale: Part of the first base-runtime prototype.
+                ref: b3d1bcab2b9bc07714a85c0e75cd5dfd2771a159
+            perl-Devel-PPPort:
+                rationale: Part of the first base-runtime prototype.
+                ref: 83609efc7114b5a028d476eab52c8b7b9baa08b0
+            perl-Devel-Refcount:
+                rationale: Part of the first base-runtime prototype.
+                ref: 664ba982f2a52078b3d304b5afce17e033cb6bd1
+            perl-Devel-Size:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1c07709b1062933b5063aac40688cdbabef24cb8
+            perl-Devel-StackTrace:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8a19f9fd951379ba3746beb68418f3eb3a53f91a
+            perl-Devel-Symdump:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6cc444451b23dfb08b55dd77a9897bc1c5e509bc
+            perl-Digest:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9ea3b5ca3550839a99bcdc071eb59e1da0dfa1fb
+            perl-Digest-CRC:
+                rationale: Part of the first base-runtime prototype.
+                ref: aa10a4d149efcf97873371022bd0556db8b9e4f7
+            perl-Digest-HMAC:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6b8330b17aaad8e0cd617aa6faf160956f2f6484
+            perl-Digest-MD5:
+                rationale: Part of the first base-runtime prototype.
+                ref: fdf1cee1b93a06bdcad445e04bed52e84721b0d9
+            perl-Digest-Perl-MD5:
+                rationale: Part of the first base-runtime prototype.
+                ref: e313336b19f39bf88a39f311a7665c77e22f25ee
+            perl-Digest-SHA1:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5193dacbc2cbb62513b621d36ff7db0da26924e9
+            perl-Digest-SHA:
+                rationale: Part of the first base-runtime prototype.
+                ref: c46b97e3d486f396feda0247c11a6e8c48b074f0
+            perl-Dist-CheckConflicts:
+                rationale: Part of the first base-runtime prototype.
+                ref: b24f120862a8f5e9cc3103a57d04dd3d0244e606
+            perl-DynaLoader-Functions:
+                rationale: Part of the first base-runtime prototype.
+                ref: 14dc7a16d67c8db54a270d7265169d4ed44a2f32
+            perl-Email-Address:
+                rationale: Part of the first base-runtime prototype.
+                ref: 885be5894baf016c839145d7d248970eff524053
+            perl-Encode:
+                rationale: Part of the first base-runtime prototype.
+                ref: 49d1c19c4ea3514e3001736cd3de24ae10d483f6
+            perl-Encode-EUCJPASCII:
+                rationale: Part of the first base-runtime prototype.
+                ref: b34779846bd7c20bbc47ec26f3090e699c4aedb3
+            perl-Encode-Locale:
+                rationale: Part of the first base-runtime prototype.
+                ref: c81a18b022013a97f71deb25a7b55f52ca746fa8
+            perl-Env:
+                rationale: Part of the first base-runtime prototype.
+                ref: 56af5d65996e2f22f60b08895746b6f99493f9ce
+            perl-Env-Sanctify:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0dec7e789998b9b73d0efcbc6243b621e55fe760
+            perl-Error:
+                rationale: Part of the first base-runtime prototype.
+                ref: 25ef6a42c89322e79305bc465ab867b5eaaec4aa
+            perl-EV:
+                rationale: Part of the first base-runtime prototype.
+                ref: ac9108242b1f9173bbdbadac78c5fd1d20ad03ad
+            perl-Eval-Closure:
+                rationale: Part of the first base-runtime prototype.
+                ref: e47f4ca49be3c97a9550e4aff5697099c27d4084
+            perl-Event:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6eedbae771ecaccbaab48c72b338294fd20e3f71
+            perl-Exception-Base:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7b002e4fb7b97813333ea2eb82c34b8ca1f6f2bd
+            perl-Exception-Class:
+                rationale: Part of the first base-runtime prototype.
+                ref: 09ecc93beaf5e5091c5898c5a1c812e26ea5c387
+            perl-Expect:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2b1b037d75cfbf08468d59f04825c069c97fac35
+            perl-Exporter:
+                rationale: Part of the first base-runtime prototype.
+                ref: 44fb1337b7d66fddf892372f1216909a08af09ac
+            perl-Exporter-Tiny:
+                rationale: Part of the first base-runtime prototype.
+                ref: 99cacc327adb0b5dd7aeffda6129929e52b6f0f0
+            perl-ExtUtils-AutoInstall:
+                rationale: Part of the first base-runtime prototype.
+                ref: d6849d5a9be0cbfa5e5993ef46db227f63c6ddf4
+            perl-ExtUtils-CBuilder:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7abb0ab18b2ac9d3943badc477f1c24acbae7ace
+            perl-ExtUtils-Config:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8e26eca470e77d83ae127e4a609f3e39c66d3e2c
+            perl-ExtUtils-Depends:
+                rationale: Part of the first base-runtime prototype.
+                ref: 41561824903684538eb31e37807dfcdb97db4614
+            perl-ExtUtils-Helpers:
+                rationale: Part of the first base-runtime prototype.
+                ref: 037cc9bdbf9c566c0e132437c5bcf28b3163eab2
+            perl-ExtUtils-Install:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1bf81970fd9ee5f04a3d28804994b53ad80400e5
+            perl-ExtUtils-InstallPaths:
+                rationale: Part of the first base-runtime prototype.
+                ref: 03c0b92db1a838ebf7978601ba849318a5d77ce8
+            perl-ExtUtils-MakeMaker:
+                rationale: Part of the first base-runtime prototype.
+                ref: 09926c7bc2abbe7efd354e634869a34c983561e9
+            perl-ExtUtils-MakeMaker-CPANfile:
+                rationale: Part of the first base-runtime prototype.
+                ref: fc2ecb0663156757113e546ecea86e0de72c7de6
+            perl-ExtUtils-Manifest:
+                rationale: Part of the first base-runtime prototype.
+                ref: a6b6284375b52bfed80542c105cf17183676543a
+            perl-ExtUtils-ParseXS:
+                rationale: Part of the first base-runtime prototype.
+                ref: e466a8289198454374216b4c3ff5ccc1c9b3c79f
+            perl-ExtUtils-PkgConfig:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9d6f74b4199c9f9f9d8ff82f6e30eac61921a0bc
+            perl-Fedora-VSP:
+                rationale: Part of the first base-runtime prototype.
+                ref: 47ccd3c726f2459d8221511173db969eef174d93
+            perl-File-BaseDir:
+                rationale: Part of the first base-runtime prototype.
+                ref: 867640c051ff3e23b1a1e49aa08d04f8ec0a72f8
+            perl-File-chmod:
+                rationale: Part of the first base-runtime prototype.
+                ref: fcd296761e0d930fcac915e09106380d3834b068
+            perl-File-Copy-Recursive:
+                rationale: Part of the first base-runtime prototype.
+                ref: ede094e0091948380287de7c3ecb0612b736188c
+            perl-File-DesktopEntry:
+                rationale: Part of the first base-runtime prototype.
+                ref: 50edef91850694185906c75e73b4e0e38c866dd2
+            perl-File-Fetch:
+                rationale: Part of the first base-runtime prototype.
+                ref: e5648e22018ae6480b84a80d6503fd456fa7913c
+            perl-File-Find-Iterator:
+                rationale: Part of the first base-runtime prototype.
+                ref: f3cd1fc45c8bbbc4a1c41e758518f33176457e7c
+            perl-File-Find-Object:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1e3aeb3383f0b9347db52bfcfb2f045401a33b29
+            perl-File-Find-Object-Rule:
+                rationale: Part of the first base-runtime prototype.
+                ref: f168055fc80786bb2f042c48afd1b5f8afcf6e21
+            perl-File-Find-Rule:
+                rationale: Part of the first base-runtime prototype.
+                ref: 13f6c32d43ae5f462644e087bac561cb113417be
+            perl-File-Find-Rule-Perl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 002b794f8070d9cc1a5d7815e84969c4e8d27583
+            perl-File-Flat:
+                rationale: Part of the first base-runtime prototype.
+                ref: 132aa16c76412f0d6fe1ae739cc1facb43b2b6d2
+            perl-FileHandle-Fmode:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8175ededc71a7f0a01ced0a6cb1edade23d505f1
+            perl-File-HomeDir:
+                rationale: Part of the first base-runtime prototype.
+                ref: 70c8f0ad2f26155016896d20aa1c5c5692722ee4
+            perl-File-Listing:
+                rationale: Part of the first base-runtime prototype.
+                ref: 61d66cc50fe17c5144c59d77d98118f939ae4033
+            perl-File-MimeInfo:
+                rationale: Part of the first base-runtime prototype.
+                ref: 86821440ffa052738ed1ac3fc342520b0f6a2a2f
+            perl-File-Path:
+                rationale: Part of the first base-runtime prototype.
+                ref: b6fb58700e473aae595ce602bcb2aebda807663d
+            perl-File-PathList:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3af46d541e9ea5466d38668050fb4b60304d7094
+            perl-File-pushd:
+                rationale: Part of the first base-runtime prototype.
+                ref: 843eeac2cf994dfff2265e51e363964facef69b1
+            perl-File-ReadBackwards:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4c7b35e8e1772530ede0e42fab265ff1d4b2d7e1
+            perl-File-Remove:
+                rationale: Part of the first base-runtime prototype.
+                ref: 96ef446141d14c2d8069af8d948fc876bfd7936d
+            perl-File-ShareDir:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7c85f28d0884a35a2661b66fc120992f4a1b9789
+            perl-File-ShareDir-Install:
+                rationale: Part of the first base-runtime prototype.
+                ref: 43de051cfa25a12dbd1ae1df311fb31c9747734d
+            perl-File-Slurp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1dc1d61856d475d21284ea1b0a5c22fa3d89e10e
+            perl-File-Slurper:
+                rationale: Part of the first base-runtime prototype.
+                ref: e711159cbcd88105293d0d4482b6937cab5f2299
+            perl-File-Slurp-Tiny:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7bf8f96951664c78f6e5b6160961595dbb474bf3
+            perl-File-Temp:
+                rationale: Part of the first base-runtime prototype.
+                ref: db2f0cffe9ffabc82bbfe2a0ed67b470062aa977
+            perl-File-Type:
+                rationale: Part of the first base-runtime prototype.
+                ref: 31733eee33cb11b62b274f04b9eef9d949e41335
+            perl-File-Which:
+                rationale: Part of the first base-runtime prototype.
+                ref: e7f4d93028fa904d24951b742b97c2f674e5ca7c
+            perl-Filter:
+                rationale: Part of the first base-runtime prototype.
+                ref: 963b12b2ff61c063e2ceb3b4f4e0b292013e6fda
+            perl-Filter-Simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8b9f3d35964c671e3c0600eaac76b1cbe0441d2b
+            perl-Font-AFM:
+                rationale: Part of the first base-runtime prototype.
+                ref: ad00b506c5ff087952b112b252a8c2e152ae6043
+            perl-Font-TTF:
+                rationale: Part of the first base-runtime prototype.
+                ref: f8a3a6df89beb08715823e964c009a7849285073
+            perl-FreezeThaw:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1621628a15a4cae0cd8ce94561455c3c1809d5be
+            perl-Future:
+                rationale: Part of the first base-runtime prototype.
+                ref: 624d9f5a76e0168cf6879435c1f4bc325c44c6a2
+            perl-GD-Barcode:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7f10268b383feaeb66433b1b3f7790e53be1c244
+            perl-GD:
+                rationale: Part of the first base-runtime prototype.
+                ref: eae53ba1a525946058d8585c5a3f2c4fd8ae400b
+            perl-generators:
+                rationale: Part of the first base-runtime prototype.
+                ref: feea81a6b01fcf7c493e1877d45549f4a849d233
+            perl-Getopt-ArgvFile:
+                rationale: Part of the first base-runtime prototype.
+                ref: cfadd45205e10f0fc039b51cb8360a5fbe1b265c
+            perl-Getopt-Long:
+                rationale: Part of the first base-runtime prototype.
+                ref: 41497c4830c449e9c5860fde2e4ae02075f90cf1
+            perl-Getopt-Long-Descriptive:
+                rationale: Part of the first base-runtime prototype.
+                ref: 52ad5dde2a45f3dcf9d30078e3cd2f5c4322bcf1
+            perl-gettext:
+                rationale: Part of the first base-runtime prototype.
+                ref: 991a24aa1450f5364cac11bd85a4fafa682ee146
+            perl-Glib:
+                rationale: Part of the first base-runtime prototype.
+                ref: ef016176e35820ca36dde9ffd94bb9432584989e
+            perl-Graph:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4bae3b83ccd7f0a2d1df53dd35dde56bcc3b6667
+            perl-GraphViz:
+                rationale: Part of the first base-runtime prototype.
+                ref: a6f0cbb1f81e28773f01a57e3aad5b4ba9de63df
+            perl-Guard:
+                rationale: Part of the first base-runtime prototype.
+                ref: f4e7a0028573874d43f01decea945bc359429b38
+            perl-Hash-Merge:
+                rationale: Part of the first base-runtime prototype.
+                ref: 758dd7f60c115a2133959b1f9d9d62d32f6ad724
+            perl-Hash-Util-FieldHash-Compat:
+                rationale: Part of the first base-runtime prototype.
+                ref: db5043144b6016e026553701eaae2caf367bf59e
+            perl-Heap:
+                rationale: Part of the first base-runtime prototype.
+                ref: f044a2d912040baee850085bb0342c0df74be3ea
+            perl-Hook-LexWrap:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4696113c6f1b9595754b30722f61d89590b2c638
+            perl-HTML-Element-Extended:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5ea855d21a37c321c033f10bc1a9d6e7d57739a5
+            perl-HTML-Format:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0a7393c8f36f8479cdc9c27332c5ab86b2cfbfea
+            perl-HTML-Parser:
+                rationale: Part of the first base-runtime prototype.
+                ref: f86907f600f9e439993ec28255a355696a60f1ed
+            perl-HTML-TableExtract:
+                rationale: Part of the first base-runtime prototype.
+                ref: d578f0cea5626f7ed602a5fcd530bbabb25d9c95
+            perl-HTML-Tagset:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4e47927d3a5f53e2fca8f3a68b639b44aa62843d
+            perl-HTML-Tree:
+                rationale: Part of the first base-runtime prototype.
+                ref: bd5d48e3c62f43e0633862919ad1183c6d889526
+            perl-HTTP-Cookies:
+                rationale: Part of the first base-runtime prototype.
+                ref: 509e2692a973dbda7ea037fcc53ece2148dcc25f
+            perl-HTTP-Daemon:
+                rationale: Part of the first base-runtime prototype.
+                ref: 571fe575d738ffaa0d88af9497edd3631178141b
+            perl-HTTP-Date:
+                rationale: Part of the first base-runtime prototype.
+                ref: b46ee13b8dbe753a56b38995eabe3a9aceb3a631
+            perl-HTTP-Message:
+                rationale: Part of the first base-runtime prototype.
+                ref: f9f2e907fda697a8e1b480ae9f8eb2ba2ebc38f8
+            perl-HTTP-Negotiate:
+                rationale: Part of the first base-runtime prototype.
+                ref: 10d02768bb95729be96cd824d5a8ffe2fbcb86a7
+            perl-HTTP-Tiny:
+                rationale: Part of the first base-runtime prototype.
+                ref: 618fd6fbe69edeb7e626a7c0c09d3494fd94afee
+            perl-Ima-DBI:
+                rationale: Part of the first base-runtime prototype.
+                ref: f463fb73f648922b0206a851480807531a9dd385
+            perl-Image-Base:
+                rationale: Part of the first base-runtime prototype.
+                ref: 46293ddcf7caff5eb927d69b8c6f3bc2c50e7a7b
+            perl-Image-Info:
+                rationale: Part of the first base-runtime prototype.
+                ref: 28b61db2c920a2d172eb0c55928332ba930ef722
+            perl-Image-Size:
+                rationale: Part of the first base-runtime prototype.
+                ref: 307c2d105c5662829d308c5e3a43c4d812cf726e
+            perl-Image-Xbm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 65da805acfbd3efd722c243c8f68314bae9c7aa7
+            perl-Image-Xpm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5ee25e023b68754b79f7645efd83ced6846d85b1
+            perl-Importer:
+                rationale: Part of the first base-runtime prototype.
+                ref: fe42e6aa7c18c3bad7bdd22b27c3a3dfae464fc0
+            perl-Import-Into:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7c766ea61393dd398e25610afe775bd5065a2791
+            perl-inc-latest:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6e020136c3c29ebeacf75a31ebbf8d17f60b4046
+            perl-indirect:
+                rationale: Part of the first base-runtime prototype.
+                ref: 650b0e5a5badf28e0405450e7120ad2dcbdccd98
+            perl-Inline:
+                rationale: Part of the first base-runtime prototype.
+                ref: 352ad6d97dbd47ea324925b3b89383d34b05a3f1
+            perl-Inline-C:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7a83b34165c906757eec4dafd6465b7d31248d03
+            perl-Inline-Files:
+                rationale: Part of the first base-runtime prototype.
+                ref: a647df1efc626e8c378f9953581fccc3b4e0c742
+            perl-IO-AIO:
+                rationale: Part of the first base-runtime prototype.
+                ref: 703e6f92b66c551b7b64713b6ef9734b570da5f5
+            perl-IO-All:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5cc3661f609d864c85f3e6392f958680311a0e23
+            perl-IO-Async:
+                rationale: Part of the first base-runtime prototype.
+                ref: f3039b9c605ac9d6c8aebd2bb8d96ce67eb3b8f4
+            perl-IO-Capture:
+                rationale: Part of the first base-runtime prototype.
+                ref: f829f6b930e2735d86e8d1c8a7af72d9726c89de
+            perl-IO-CaptureOutput:
+                rationale: Part of the first base-runtime prototype.
+                ref: dda616c0dc39233f7bec5c8227c7090c249e02ba
+            perl-IO-Compress:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0387ba0667f2e02cbaac986259ce7ade8a28b9cb
+            perl-IO-HTML:
+                rationale: Part of the first base-runtime prototype.
+                ref: b8064f321285096eebcc93741625966c090ba6a3
+            perl-IO-Pipely:
+                rationale: Part of the first base-runtime prototype.
+                ref: effb139138458b25b8071b1a802c3e3433a2d717
+            perl-IO-Socket-INET6:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1a3c068e6be6b73a000bde93b6ea36d9c5ea666b
+            perl-IO-Socket-IP:
+                rationale: Part of the first base-runtime prototype.
+                ref: bf55dc7e938bc799b071e923aa7aaa9559895af2
+            perl-IO-Socket-SSL:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4b64c34a03353809a386baf462e04c433be1685e
+            perl-IO-String:
+                rationale: Part of the first base-runtime prototype.
+                ref: d02c598b6e8a20cbd417b682b932ac57039a17ea
+            perl-IO-stringy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3c34e10f8a5e4022ac8da8aaad56bbb201eeffb7
+            perl-IO-Tty:
+                rationale: Part of the first base-runtime prototype.
+                ref: 945a803574a42b78413caa7ebca331d3c8981e2d
+            perl-IPC-Cmd:
+                rationale: Part of the first base-runtime prototype.
+                ref: e13ec770ce649571b6b60c02b31cea704d9e7af7
+            perl-IPC-Run3:
+                rationale: Part of the first base-runtime prototype.
+                ref: f80b221e4da3a3ae5b9972a4cb9eb86dae8f6a32
+            perl-IPC-Run:
+                rationale: Part of the first base-runtime prototype.
+                ref: bfec7d7b476c2a8b60c337ddc6afdc89d4b96c63
+            perl-IPC-System-Simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94bae4076174be8ef3300ec9df4d5b4a5f62989f
+            perl-IPC-SysV:
+                rationale: Part of the first base-runtime prototype.
+                ref: 647aca3629089b71a5b5611819cd224d67bf04c2
+            perl-Jcode:
+                rationale: Part of the first base-runtime prototype.
+                ref: 728cb820d86a2462a1be23ccc516c87e7e987561
+            perl-JSON-Any:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8f28125a78119d31662748e21ba1c31b0f71a5fd
+            perl-JSON:
+                rationale: Part of the first base-runtime prototype.
+                ref: e48ce25e22d24f2f729033114d07178ca300e6e7
+            perl-JSON-MaybeXS:
+                rationale: Part of the first base-runtime prototype.
+                ref: d1efa8980dd2d1463d8bd718e323372fce048d56
+            perl-JSON-PP:
+                rationale: Part of the first base-runtime prototype.
+                ref: 80ea84cc73a0c7205e2f3adcd14bb0082f52cb5f
+            perl-JSON-XS:
+                rationale: Part of the first base-runtime prototype.
+                ref: 72d4dd8eac951829822061009354cf29befe8a24
+            perl-Lexical-SealRequireHints:
+                rationale: Part of the first base-runtime prototype.
+                ref: ade24d70ec1314f771140e3fcc311eac5f61b8d3
+            perl-Lexical-Var:
+                rationale: Part of the first base-runtime prototype.
+                ref: 39b9abce77ef61e13188f4990b369a43301bfc4c
+            perl-libintl-perl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 03f6549e267cc1e95f07d82b6aec4b593335292d
+            perl-libnet:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1694750fa87e2bd6db16665a3be50e46e335fd09
+            perl-libwww-perl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3c42be5b38853c14d698c3f9352c23d6f86b271a
+            perl-libxml-perl:
+                rationale: Part of the first base-runtime prototype.
+                ref: a297e5f5810462dfbffb2b102f2d431838001292
+            perl-Lingua-EN-Inflect:
+                rationale: Part of the first base-runtime prototype.
+                ref: 055e6b66bb394538d922807f1ac70f3310650d72
+            perl-List-MoreUtils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 381ebe97babc7b3e90e187e5d82203ae2e0f950c
+            perl-Locale-Maketext:
+                rationale: Part of the first base-runtime prototype.
+                ref: 56a2b4e78b4a7e521a19d879f00f0db264488378
+            perl-Locale-US:
+                rationale: Part of the first base-runtime prototype.
+                ref: b48dd55747c1597a69d3675c136560bd4f389a6f
+            perl-local-lib:
+                rationale: Part of the first base-runtime prototype.
+                ref: c119014c35d44368b61e2f19f920d002e1e4d214
+            perl-Log-Message:
+                rationale: Part of the first base-runtime prototype.
+                ref: d29a1786259b23ad1f6216e4c0e8f1a635da644f
+            perl-Log-Message-Simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: c5ffa9c7a919367bf086ee8dba7d7485b62c2321
+            perl-LWP-MediaTypes:
+                rationale: Part of the first base-runtime prototype.
+                ref: 55d212ff7e05f9eb0c7459321240a46a006c5f4c
+            perl-Math-Base36:
+                rationale: Part of the first base-runtime prototype.
+                ref: dcbe23f2b0a9f6bc821d9f6f77471d71fc57502c
+            perl-Math-Base-Convert:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9e0f99cd025a6b28d22227ffa5847d66e573f1f9
+            perl-Math-BigInt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 59f32187b5be427d38c6c0b1999118cd51b153fd
+            perl-MCE:
+                rationale: Part of the first base-runtime prototype.
+                ref: cd09dd2c5f08b911d15ec363c362430ca23344d6
+            perl-MIME-Base64:
+                rationale: Part of the first base-runtime prototype.
+                ref: b0d5e3adaa9dd878597415ac4a6dda58473b7e41
+            perl-MIME-Charset:
+                rationale: Part of the first base-runtime prototype.
+                ref: c8d84931e60f97402b6877a6026e50e4086bcd72
+            perl-Mixin-Linewise:
+                rationale: Part of the first base-runtime prototype.
+                ref: a54ec76d89903264e180efdc17440d632182e81c
+            perl-MLDBM:
+                rationale: Part of the first base-runtime prototype.
+                ref: 926cd7ebbc09045175aad0a4bd85f6642ffcf502
+            perl-Module-Build:
+                rationale: Part of the first base-runtime prototype.
+                ref: 118b551eb3833c498281df39938cc43e577e1740
+            perl-Module-Build-Deprecated:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2687978cb7684a8288ac3320e2911a819ffee787
+            perl-Module-Build-Tiny:
+                rationale: Part of the first base-runtime prototype.
+                ref: f994a623d15d0bbf69c130c2e51727426aece6f4
+            perl-Module-Build-XSUtil:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1afb1e6ee4c6d5e9d8de1346d53d10d24f190da0
+            perl-Module-CoreList:
+                rationale: Part of the first base-runtime prototype.
+                ref: bf0277310a8d297f445c28ed130b29fed1c7a538
+            perl-Module-CPANfile:
+                rationale: Part of the first base-runtime prototype.
+                ref: fd3457f7993ceae4d3ef137e275ad318fba51be2
+            perl-Module-CPANTS-Analyse:
+                rationale: Part of the first base-runtime prototype.
+                ref: a745403ae2ea27f37cf57af3286c87cf2f3154a1
+            perl-Module-ExtractUse:
+                rationale: Part of the first base-runtime prototype.
+                ref: acb6f495bcb44b4d95c96ed955823255e3f04757
+            perl-Module-Find:
+                rationale: Part of the first base-runtime prototype.
+                ref: 465ed64883ba7d52c9f80e1c8a57280300d38f8a
+            perl-Module-Implementation:
+                rationale: Part of the first base-runtime prototype.
+                ref: 882b925d847788056a3ce9c1bd6b5f3a55270b4a
+            perl-Module-Info:
+                rationale: Part of the first base-runtime prototype.
+                ref: 514d842f0566117af7c475f716b5df8ae1105bb1
+            perl-Module-Install:
+                rationale: Part of the first base-runtime prototype.
+                ref: 26d5e87f4aaed0b9f6eb48a3cd130c8d9f78ca8e
+            perl-Module-Install-AuthorRequires:
+                rationale: Part of the first base-runtime prototype.
+                ref: ea7823d5e44853c7643a4493636eb536369a0ea0
+            perl-Module-Install-AuthorTests:
+                rationale: Part of the first base-runtime prototype.
+                ref: ba98b6feac79bf193296fe76a3b3e9d2890ffcc3
+            perl-Module-Install-AutoLicense:
+                rationale: Part of the first base-runtime prototype.
+                ref: be31f1240893156d47f41a8eb452c8f441e77b57
+            perl-Module-Install-ExtraTests:
+                rationale: Part of the first base-runtime prototype.
+                ref: c934edfb681bce7a0bf895c476d0baa998487a49
+            perl-Module-Install-GithubMeta:
+                rationale: Part of the first base-runtime prototype.
+                ref: 19ef205bcff3bca5f12f0de9937de6758b73e445
+            perl-Module-Install-ManifestSkip:
+                rationale: Part of the first base-runtime prototype.
+                ref: bf100e99be84a0f185a619d476a2682235a37af6
+            perl-Module-Install-ReadmeFromPod:
+                rationale: Part of the first base-runtime prototype.
+                ref: 38359dd1654c664ab0b11335a06b18ea8a4e4297
+            perl-Module-Install-ReadmeMarkdownFromPod:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9037f98ed3ec5b55e51464824bd249348ce98c74
+            perl-Module-Install-Repository:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7dc713e6583a737b8dfcb3eb1088c868270553ff
+            perl-Module-Load-Conditional:
+                rationale: Part of the first base-runtime prototype.
+                ref: 84baeee30d4e4ee293203b589c16eac710dcd14c
+            perl-Module-Load:
+                rationale: Part of the first base-runtime prototype.
+                ref: eba36e3fee569a9654ac849e626fa128b248cf41
+            perl-Module-Manifest:
+                rationale: Part of the first base-runtime prototype.
+                ref: fa86c152dd1b6a27d75e5467a7380b5adc4e73e4
+            perl-Module-Manifest-Skip:
+                rationale: Part of the first base-runtime prototype.
+                ref: 80a7c419535ec09c4776aa39c3bde5d65e110152
+            perl-Module-Metadata:
+                rationale: Part of the first base-runtime prototype.
+                ref: d31e93bc20bfc5d74c1803db5fd09f1548372b2b
+            perl-Module-Package:
+                rationale: Part of the first base-runtime prototype.
+                ref: adc4ad0b70bde9ac437fd03cd4597fee409b90ac
+            perl-Module-Package-Au:
+                rationale: Part of the first base-runtime prototype.
+                ref: e3b24e7918d39580e1cf3c4a27c3be11b0fe6847
+            perl-Module-Path:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7428016609e38af996332240ea9d38b06824df87
+            perl-Module-Pluggable:
+                rationale: Part of the first base-runtime prototype.
+                ref: ff8e5732d40b786f349e325dcbd74d5f291e3ab7
+            perl-Module-Refresh:
+                rationale: Part of the first base-runtime prototype.
+                ref: 19bc2cbac579ed4cc134916567e9aae8ce5775e4
+            perl-Module-Runtime:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9c4ae14d1f908876525c7e88c8401b5867b3301c
+            perl-Module-Runtime-Conflicts:
+                rationale: Part of the first base-runtime prototype.
+                ref: 13f53d3cd57e1a4e06dc3c0eab5fba71fa7db4e5
+            perl-Module-ScanDeps:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5c90b82b28474b71ff2c0cf171f665c1b9e12aba
+            perl-Module-Signature:
+                rationale: Part of the first base-runtime prototype.
+                ref: bcbf81acdc57852822503e771a128bfacff94004
+            perl-Mojolicious:
+                rationale: Part of the first base-runtime prototype.
+                ref: bf0907c61151def655ab30c00ebdc4dd78e9b15e
+            perl-Moo:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3ea578ae8742ad4d383b083681011aa5b087c39c
+            perl-Moose:
+                rationale: Part of the first base-runtime prototype.
+                ref: b032be88ab92d2aafff1a138e2d36e018d0662ea
+            perl-Moose-Autobox:
+                rationale: Part of the first base-runtime prototype.
+                ref: cc4ce713c6546fc6a2440746a0709d4a2e91ed7f
+            perl-MooseX-AttributeHelpers:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4bb450103130aff2370c58719eafa2add999e92e
+            perl-MooseX-ConfigFromFile:
+                rationale: Part of the first base-runtime prototype.
+                ref: fd5b82a13aa8a9832b07d0ca2821b08f2930ba40
+            perl-MooseX-Getopt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 37455b846ee5759a1fa79c7aba63efac727359d6
+            perl-MooseX-GlobRef:
+                rationale: Part of the first base-runtime prototype.
+                ref: cec228144914375180e234e8564740f88bb739fe
+            perl-MooseX-InsideOut:
+                rationale: Part of the first base-runtime prototype.
+                ref: cfd9d9d05202d6885c9322115df10fcbb8d536ff
+            perl-MooseX-MarkAsMethods:
+                rationale: Part of the first base-runtime prototype.
+                ref: 477282ab592e0ec2bf1a6ee279ff14c0a5942a3b
+            perl-MooseX-NonMoose:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3f8e9286fb4867ddb4383b30f839ce63fe1704ef
+            perl-MooseX-Role-Parameterized:
+                rationale: Part of the first base-runtime prototype.
+                ref: a98e6d65454616b39c1cefdc33c06f84931f1688
+            perl-MooseX-Role-WithOverloading:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8755141e92f5e46942a032838c30aaf9ad153b5e
+            perl-MooseX-SimpleConfig:
+                rationale: Part of the first base-runtime prototype.
+                ref: d253ed79127316aeac7c4281e936a86f7dc82dfa
+            perl-MooseX-StrictConstructor:
+                rationale: Part of the first base-runtime prototype.
+                ref: de14367d239ca5b433d5d9f8093b018b95851ece
+            perl-MooseX-Types:
+                rationale: Part of the first base-runtime prototype.
+                ref: 378ec5b4a32b0706f15a56f0166c6c574abb1efa
+            perl-MooseX-Types-Common:
+                rationale: Part of the first base-runtime prototype.
+                ref: daed6d92fc726b0db00aa4ed524fc9d733733fa0
+            perl-MooseX-Types-JSON:
+                rationale: Part of the first base-runtime prototype.
+                ref: b44387de9dd6b78b32dfe1ffa4ccc20ba0d4e39f
+            perl-MooseX-Types-LoadableClass:
+                rationale: Part of the first base-runtime prototype.
+                ref: c52abe935291fce87210132d2f186be41ad0f721
+            perl-MooseX-Types-Path-Class:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6876713fcaaecd3a74196dd01c7307a8dde55acd
+            perl-MooseX-Types-Path-Tiny:
+                rationale: Part of the first base-runtime prototype.
+                ref: d548567feb19017e5fbb34cb7b4a1614dfdd6223
+            perl-MooseX-Types-Stringlike:
+                rationale: Part of the first base-runtime prototype.
+                ref: 234f00151ca001e9dff300e08c911f4fc56ce30b
+            perl-MooX-HandlesVia:
+                rationale: Part of the first base-runtime prototype.
+                ref: e3c9e3104f85df4508835264ddc6462e3221ab42
+            perl-MooX-Types-MooseLike:
+                rationale: Part of the first base-runtime prototype.
+                ref: a745054e94cbb836fe9f19e9787b2d8a06ca72af
+            perl-Mouse:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4c651e16eb7785ea424296107d135f1abcae6628
+            perl-MouseX-Types:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7d51b1a68422fd0f494280be9b747c6bd4e35380
+            perl-MRO-Compat:
+                rationale: Part of the first base-runtime prototype.
+                ref: 47b59dca5ff5f0d1817c94a4237a040ea5443c80
+            perl-multidimensional:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0cafb082711031a44fa7847bc67e86c39d53e83f
+            perl-namespace-autoclean:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8bdf5b491ca17f732be804c169ea77c759b090af
+            perl-namespace-clean:
+                rationale: Part of the first base-runtime prototype.
+                ref: 48f060b587fcc1773f6dc42812a759038c293993
+            perl-Net-HTTP:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5ddd867a6af87aec49cfcb900a89bd97fb9ec31f
+            perl-Net-IDN-Encode:
+                rationale: Part of the first base-runtime prototype.
+                ref: 02a595bf497288f83205bda219a6ebc5fff986b2
+            perl-Net-LibIDN:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0a8678441789726c36524455d8505a976f2d4e57
+            perl-Net-SSLeay:
+                rationale: Part of the first base-runtime prototype.
+                ref: a218f8cfdaea5e205124d76fa20374645fe9caf3
+            perl-NTLM:
+                rationale: Part of the first base-runtime prototype.
+                ref: e682b60bf8899607a16e1e76b8dd91c5e4751ffc
+            perl-Number-Compare:
+                rationale: Part of the first base-runtime prototype.
+                ref: 24cbab3675f5cdb8fa3d3af7394830bcd44b421b
+            perl-Number-Format:
+                rationale: Part of the first base-runtime prototype.
+                ref: 95873309c461a4e16c34df470b4eca7757fc3199
+            perl-Object-Accessor:
+                rationale: Part of the first base-runtime prototype.
+                ref: a99787da9e6e0b7b6ff93dda2f143da52ec88033
+            perl-Object-Deadly:
+                rationale: Part of the first base-runtime prototype.
+                ref: 53bbbbb64ab20907043a496fc60796bada767876
+            perl-OLE-Storage_Lite:
+                rationale: Part of the first base-runtime prototype.
+                ref: f27b1fa7956938e07cfb11068aa14dbf0c6a1cac
+            perl-Package-Anon:
+                rationale: Part of the first base-runtime prototype.
+                ref: fadebe413c375fa9afac763b796958367a18e601
+            perl-Package-Constants:
+                rationale: Part of the first base-runtime prototype.
+                ref: c88667cbbb3a307bfb0094be6fb09bf013fe43f2
+            perl-Package-DeprecationManager:
+                rationale: Part of the first base-runtime prototype.
+                ref: d9dfc85ab52f30f5a6ab62df1de4c74df08e8908
+            perl-Package-Generator:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8fac41725a2c99093d901e9a7bb11f4d514d5fd7
+            perl-Package-Stash:
+                rationale: Part of the first base-runtime prototype.
+                ref: fc0fe5e1ff31e8268f163cd0468401ffe9f86068
+            perl-Package-Stash-XS:
+                rationale: Part of the first base-runtime prototype.
+                ref: b241a0e2d4c80e2dddf0dfe851b19a2ab07910e5
+            perl-Package-Variant:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4f0e9a2d249a50aa1c83ef0daa9942e1ec6312f9
+            perl-PadWalker:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3e2829e69c9b771d839ef2a5d0f5fa4ad58ae39e
+            perl-Paper-Specs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3b7b2f9c2969cef48084bc93bdafb95f0b77ed72
+            perl-Parallel-ForkManager:
+                rationale: Part of the first base-runtime prototype.
+                ref: 320068d37157ce86ab852adc354ff90fae626326
+            perl-Params-Check:
+                rationale: Part of the first base-runtime prototype.
+                ref: 33f7e499820ce66078fd510c96b8a632aac47e5f
+            perl-Params-Classify:
+                rationale: Part of the first base-runtime prototype.
+                ref: 56bc3a46373335466ba0061aa772dccdf14502c6
+            perl-Params-Coerce:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0670c340e574b0ef36a672e95316efd1fb7d95fe
+            perl-Params-Util:
+                rationale: Part of the first base-runtime prototype.
+                ref: b4b67af7b93c1f215b847f2b91025cf5d953b506
+            perl-Params-Validate:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7bd138ca951e691be137770590f39c7080803034
+            perl-Params-ValidationCompiler:
+                rationale: Part of the first base-runtime prototype.
+                ref: f9b3c33deac73dccf81d623afcc34f59f751f42f
+            perl-PAR-Dist:
+                rationale: Part of the first base-runtime prototype.
+                ref: a102ac1c5fc7ce459c52ba56aa2bf265976b54d9
+            perl-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 44ecf7523d3822fed3ab4b1535198e98a7dc1695
+            perl-Parse-CPAN-Meta:
+                rationale: Part of the first base-runtime prototype.
+                ref: 51657b096eaa8fd0325035d82f0dba744fe0e0b9
+            perl-Parse-RecDescent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 21bed961f11df91713f8455425ccf6a615d4ea49
+            perl-Parse-Yapp:
+                rationale: Part of the first base-runtime prototype.
+                ref: cb222476e7edb3971b600586d804ca94a9ae2990
+            perl-Path-Class:
+                rationale: Part of the first base-runtime prototype.
+                ref: fb1634d0d63a6cbf8d861bbbc5349a58ff7c6346
+            perl-Path-Tiny:
+                rationale: Part of the first base-runtime prototype.
+                ref: d8046b42afb1796831d2bd6c2c4cb01a2e2e1917
+            perl-PathTools:
+                rationale: Part of the first base-runtime prototype.
+                ref: d7655b9ead71491b521428df5ee2b36773fc4a8d
+            perl-PDF-API2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 40846aebebef9450fe52df530b6b151718194033
+            perl-Pegex:
+                rationale: Part of the first base-runtime prototype.
+                ref: b024f77541e5e3a30604de2a6cc63e240359b934
+            perl-Perl-Critic:
+                rationale: Part of the first base-runtime prototype.
+                ref: 660dbe2a4ec2abd1a593ef98da5ba9bdfef8c994
+            perl-Perl-Critic-Bangs:
+                rationale: Part of the first base-runtime prototype.
+                ref: a8bca642abc07bab1bd46a42ae94f7ddbbcf8d99
+            perl-Perl-Critic-Compatibility:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7dfc0113e049e514feaf192aff75a185dcd91331
+            perl-Perl-Critic-Deprecated:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4a4ce6d83624babc46a881eb8b4486805ef8e1c3
+            perl-Perl-Critic-Dynamic:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6852cf26cd3e1185f07085685c99347c9debfc6f
+            perl-Perl-Critic-Itch:
+                rationale: Part of the first base-runtime prototype.
+                ref: 18c85a434ad18405ad2914f2086ec414873e55a0
+            perl-Perl-Critic-Lax:
+                rationale: Part of the first base-runtime prototype.
+                ref: a6bb85ed5fe9ed91c1f7e958fa7249d9ebc7858b
+            perl-Perl-Critic-More:
+                rationale: Part of the first base-runtime prototype.
+                ref: f24c710555ba94725d37fe1cf619a406d28d5f6c
+            perl-Perl-Critic-Moose:
+                rationale: Part of the first base-runtime prototype.
+                ref: fc62d1698420342fdac599a79a7260ad912f2e79
+            perl-Perl-Critic-Nits:
+                rationale: Part of the first base-runtime prototype.
+                ref: 03e12b3527f91f95cad4be22de0db01cebbbee9f
+            perl-Perl-Critic-PetPeeves-JTRAMMELL:
+                rationale: Part of the first base-runtime prototype.
+                ref: fa9ed5bec39ee563f2194c88749469ff3315f821
+            perl-Perl-Critic-Pulp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0715086bcd6625c464e7705edff4a97b957e3c51
+            perl-Perl-Critic-Storable:
+                rationale: Part of the first base-runtime prototype.
+                ref: e7e8032106b2367745ef4b71e0a3d6c149aae86d
+            perl-Perl-Critic-StricterSubs:
+                rationale: Part of the first base-runtime prototype.
+                ref: f92daf007e5979f3d6a5af1df8c34254b158fed6
+            perl-Perl-Critic-Swift:
+                rationale: Part of the first base-runtime prototype.
+                ref: 740d96d62b0d838e66b290fffd44d634cc8fa5ce
+            perl-Perl-Critic-Tics:
+                rationale: Part of the first base-runtime prototype.
+                ref: ddca63239cc59567f3038262e4a823ff663e9c21
+            perl-Perl-Destruct-Level:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5e8a09c0e0998718ad7ee9d0967aebce23680f62
+            perl-perlindex:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8aae8c43e93520e2eb27e28554093e55732d4cfa
+            perl-PerlIO-utf8_strict:
+                rationale: Part of the first base-runtime prototype.
+                ref: 516e460238837761cc3c9b2216499abf730bae69
+            perl-Perl-Metrics-Simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: 151c31a44d3a13a84e98b5aa0b9ef45b3440c30f
+            perl-Perl-MinimumVersion:
+                rationale: Part of the first base-runtime prototype.
+                ref: 09af8d5a1cf4239765a991ca9bf9f48ffaccd478
+            perl-Perl-OSType:
+                rationale: Part of the first base-runtime prototype.
+                ref: 819f1d3a8aaa52957e5cbc5c21291c84896938cb
+            perl-Perl-PrereqScanner:
+                rationale: Part of the first base-runtime prototype.
+                ref: aa7b5bc007deb57e5474857a8b6652588da4cfc2
+            perl-Perl-Version:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1dc8aa7f42c91a27638ff25a6c1b9b3077691918
+            perl-pod2pdf:
+                rationale: Part of the first base-runtime prototype.
+                ref: ab8cc15eb3aa16f5b92941215b9d8349ba8e9618
+            perl-Pod-Checker:
+                rationale: Part of the first base-runtime prototype.
+                ref: bd86c154aa4ac88c544ef2617802799455cc54fd
+            perl-Pod-Coverage:
+                rationale: Part of the first base-runtime prototype.
+                ref: c2c6e9ad4575a70f40c6e7f8525f2ee20546547e
+            perl-Pod-Coverage-Moose:
+                rationale: Part of the first base-runtime prototype.
+                ref: d1ab28f5883baf4bdd4043048735ccb456af56fd
+            perl-Pod-Coverage-TrustPod:
+                rationale: Part of the first base-runtime prototype.
+                ref: d6a3765ee6383ba15956aad4251ed46ecf6e14e3
+            perl-Pod-Escapes:
+                rationale: Part of the first base-runtime prototype.
+                ref: 84a240c5d9cc6799b84a8f6c3b67e4ab2b454abc
+            perl-Pod-Eventual:
+                rationale: Part of the first base-runtime prototype.
+                ref: 10c7a9d4b8379809d9079b497bd5ef05202c0533
+            perl-podlators:
+                rationale: Part of the first base-runtime prototype.
+                ref: 12274df2207d4f9ea8f69cbe12b4023484fb2d28
+            perl-podlinkcheck:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3f45fb5aed9dd5132ca3d04f406a1183ee06b61d
+            perl-Pod-Markdown:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1155db6addf3b89f053d6bf3200bfac40049dd18
+            perl-Pod-MinimumVersion:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5cada46e470c872967ce3a73412c57365bda7fa9
+            perl-Pod-Parser:
+                rationale: Part of the first base-runtime prototype.
+                ref: 36186c2aeaa4cc1b2854e8b6ff85f5ee86b18922
+            perl-Pod-Perldoc:
+                rationale: Part of the first base-runtime prototype.
+                ref: eac0df4627883e2498164c0d685763bf78591581
+            perl-Pod-POM:
+                rationale: Part of the first base-runtime prototype.
+                ref: e06915b3374f1c941eb040c5bbd445d925bb59db
+            perl-Pod-Readme:
+                rationale: Part of the first base-runtime prototype.
+                ref: 98c4181456ae8b51541032f9cf5313ee6e7941d0
+            perl-Pod-Simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: d042968560e428db87cd73cf7d8c67e97adfe268
+            perl-Pod-Spell:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4fa16285c0adced9c8e80996547452b3be579a77
+            perl-Pod-Spell-CommonMistakes:
+                rationale: Part of the first base-runtime prototype.
+                ref: 26cfcb7053137e84212c724465510ff491ddebc1
+            perl-Pod-Strip:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1d3a5b6248eaca695d83ee165be4fe07e58f2f3b
+            perl-Pod-Tests:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1a18c8ebd2033245c5098f467e5916b8eec5605e
+            perl-Pod-Usage:
+                rationale: Part of the first base-runtime prototype.
+                ref: f543b6e6306405591f51d3f0d2d011d3a23bb8cb
+            perl-POE:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1528b7c25be3b249425f0d3aa40936b99e6bcea5
+            perl-POE-Test-Loops:
+                rationale: Part of the first base-runtime prototype.
+                ref: e92f1115e2bcc47e4b307d46975ba82165845515
+            perl-PPI:
+                rationale: Part of the first base-runtime prototype.
+                ref: 16f93be17bffdd8e509ed4f4eb45f2c732eee524
+            perl-PPIx-Regexp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 25885290a25890c291c838bf6cb2cdf126864535
+            perl-PPIx-Utilities:
+                rationale: Part of the first base-runtime prototype.
+                ref: 10dea46d0b518ceab5e284163e051e89ed1a1655
+            perl-prefork:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2a3a45bdd85533c16f5c25032b5d135c5d4c671b
+            perl-Probe-Perl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2438117930961b78feeb22711b69ec7a219ebbbb
+            perl-Readonly:
+                rationale: Part of the first base-runtime prototype.
+                ref: a8f7952ff426415f0b076cc620057e5ba76cf580
+            perl-Readonly-XS:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8aa3f645f65b0889df1006aadbe486997579c440
+            perl-Regexp-Common:
+                rationale: Part of the first base-runtime prototype.
+                ref: f9970127a191547557e69ebcbdac0c69e9997a52
+            perl-Role-Tiny:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8b0c8b20b43d041a29c9d777c8cd2650d591a5f9
+            perl-Scalar-List-Utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: bde2ecb7c534556a990660196892bfb2ce46d1dc
+            perl-Scope-Guard:
+                rationale: Part of the first base-runtime prototype.
+                ref: b51bbdad3852fa81ebd5b46ef407505780ed77d0
+            perl-Sereal:
+                rationale: Part of the first base-runtime prototype.
+                ref: cc38af4fd413aaa3d95565a542bb16406fd55e76
+            perl-Sereal-Decoder:
+                rationale: Part of the first base-runtime prototype.
+                ref: 73c84f8cf3ad5e6a607e9873af44fc5053f1f609
+            perl-Sereal-Encoder:
+                rationale: Part of the first base-runtime prototype.
+                ref: ae3b1befb7ebfb0292335d17b99ed097702d9f55
+            perl-Set-Scalar:
+                rationale: Part of the first base-runtime prototype.
+                ref: f735de90dc83d81f4e8ef272494463b778b703dd
+            perl-SGMLSpm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 02b93b4c57724c5f79f0ca92a5e2757aacdd356e
+            perl-Socket:
+                rationale: Part of the first base-runtime prototype.
+                ref: 12460968b04831be24205e64f3d22f963f9b6a28
+            perl-Socket6:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6eecb52df237460c52dd7692e755913f26bd9fce
+            perl-Software-License:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2617c37fffff2f1fde7fa1b5294819c8290c7234
+            perl-Software-License-CCpack:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9a64b47fbf9f48faaa214e7c3196b71104fe0077
+            perl-Sort-Versions:
+                rationale: Part of the first base-runtime prototype.
+                ref: 85d55531f6b6a582f5fe43d4eb6cd2251a2af9be
+            perl-Specio:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5fe1a9fd14da9138e5a41f8b8e80b0e6cded367c
+            perl-Spellunker:
+                rationale: Part of the first base-runtime prototype.
+                ref: 01eee9842a756ac6494f7d05d8a4633049270741
+            perl-Spiffy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 17c6dab447eee14c088d30261d9f8228c4fc412d
+            perl-Spreadsheet-ParseExcel:
+                rationale: Part of the first base-runtime prototype.
+                ref: a7d267af524f58e8b329fa915bd0a4951ec2e0a1
+            perl-Spreadsheet-WriteExcel:
+                rationale: Part of the first base-runtime prototype.
+                ref: dac003dfbfd883de0006a71fa9d0dc8fe55dfe60
+            perl-SQL-Abstract:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1c7cdd86670325c9c818fca01b55fbd3c89ad3e2
+            perl-SQL-Interp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 967460e8e496f27de86cdf941790524de8a5b28e
+            perl-SQL-Statement:
+                rationale: Part of the first base-runtime prototype.
+                ref: 01c11e56ab9372b2ac6a7a7a224e4d5838bc002f
+            perl-SQL-Translator:
+                rationale: Part of the first base-runtime prototype.
+                ref: fec0c98c0c121efa5b5dbc03914874dc93f2d133
+            perl-srpm-macros:
+                rationale: Part of the first base-runtime prototype.
+                ref: fd204333523f7080cc69314b92ab235024ecaa1f
+            perl-Statistics-Basic:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9aa0f9576cb892d74b04edb7c9709fa67511315b
+            perl-Storable:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0b98b2693bdd51d016dcd1c7ac1a7fa5bfbae804
+            perl-strictures:
+                rationale: Part of the first base-runtime prototype.
+                ref: 390abf1e2f8024a53abb8047194f0ae004344859
+            perl-String-Format:
+                rationale: Part of the first base-runtime prototype.
+                ref: 337e5dce01be9933c7f1f2f946d6e44b820ad5f9
+            perl-String-RewritePrefix:
+                rationale: Part of the first base-runtime prototype.
+                ref: b2c8f2e683391396324710d888bad5ee8148264c
+            perl-Struct-Dumb:
+                rationale: Part of the first base-runtime prototype.
+                ref: 57064bb5c546a7b57bd9b30c37d9be33d4ed7ba4
+            perl-Sub-Exporter:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4f96d324b22c86eca7fa87c1ec53b8307272b9f6
+            perl-Sub-Exporter-ForMethods:
+                rationale: Part of the first base-runtime prototype.
+                ref: 03b0c2bbc48b3ca0456027b2d512cbb50c6ffd02
+            perl-Sub-Exporter-Progressive:
+                rationale: Part of the first base-runtime prototype.
+                ref: 45146df50c979cfbe1be281a4c7812db08060ed5
+            perl-Sub-Identify:
+                rationale: Part of the first base-runtime prototype.
+                ref: 848885154d266e61a8df05924109bd950119b36b
+            perl-Sub-Install:
+                rationale: Part of the first base-runtime prototype.
+                ref: d1e2ffa21c64eb94f2e8e510a6a442334f2c067a
+            perl-Sub-Name:
+                rationale: Part of the first base-runtime prototype.
+                ref: 44773b8d290a2e5ae9607d1594dc9e5fe96499f6
+            perl-Sub-Uplevel:
+                rationale: Part of the first base-runtime prototype.
+                ref: d9b55f0f7a8756b7eba295d766bc65d4f44cb71b
+            perl-SUPER:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0795510e9965836e51f54a039bdb3338db6b36c7
+            perl-Switch:
+                rationale: Part of the first base-runtime prototype.
+                ref: 21dcf611b7620f38c3d1b2c209253d2a62217ee0
+            perl-Symbol-Util:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5b3566b49609cdec1b5227a39784343d04705011
+            perl-syntax:
+                rationale: Part of the first base-runtime prototype.
+                ref: e576e9ab87fc991a5947b5dbacec75fe68820c9d
+            perl-Syntax-Keyword-Junction:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0ef4c1ebff4870a8b3da9df9647a7b5e64299d70
+            perl-Sys-Syslog:
+                rationale: Part of the first base-runtime prototype.
+                ref: e891b05bfcd7562a2fda4e991c5a59a91b3063de
+            perl-Taint-Runtime:
+                rationale: Part of the first base-runtime prototype.
+                ref: 20b46bc78a4f5a24c498264c1fe3ac088d62e899
+            perl-TAP-Formatter-HTML:
+                rationale: Part of the first base-runtime prototype.
+                ref: de04f4123e95dfa96806a96d017f63f44419f1a2
+            perl-Task-Perl-Critic:
+                rationale: Part of the first base-runtime prototype.
+                ref: b97b01f86906fced9051144aa29f0b9c7639cbc7
+            perl-Task-Weaken:
+                rationale: Part of the first base-runtime prototype.
+                ref: 48ceaf2554e8101aded34d4e8da9af9b71e1ab56
+            perl-Template-Toolkit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 837b647cbb146f37717891337ee29d49aa92e6d2
+            perl-Template-Toolkit-Simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: fd8f6f869fb904ec987114dad52fe93b71b5b772
+            perl-Term-ANSIColor:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5d0fcee6658e2c93b762acda8706cad430a69afd
+            perl-Term-Cap:
+                rationale: Part of the first base-runtime prototype.
+                ref: c4527170695adfcfd07970c754217dd0200fd3ef
+            perl-TermReadKey:
+                rationale: Part of the first base-runtime prototype.
+                ref: df1b226a00572cfdf8c8bcce9b78263c813c7225
+            perl-Term-UI:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3c05fd9a86441d161fb0ad5af2ce9bfcca161dae
+            perl-Test2-Plugin-NoWarnings:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6ceee59fb92b2634b5e9a072f86956ca43f61c3b
+            perl-Test2-Suite:
+                rationale: Part of the first base-runtime prototype.
+                ref: 958e51e734086d8a8caeec6cf19c2da998f57bf1
+            perl-Test-Apocalypse:
+                rationale: Part of the first base-runtime prototype.
+                ref: ad255c5b6e381c1eda329bc495ed06af1bbcd3eb
+            perl-Test-Assert:
+                rationale: Part of the first base-runtime prototype.
+                ref: 48264162cb7e85e8a8dd7c48c4f363ba0030cfb1
+            perl-Test-AutoLoader:
+                rationale: Part of the first base-runtime prototype.
+                ref: dd56df7cd84d8c03fc3ffbde73320a4f37aaa896
+            perl-Test-Base:
+                rationale: Part of the first base-runtime prototype.
+                ref: fd02504f71c6d6583c927faa9ba91ddeea215231
+            perl-Test-CheckChanges:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1645e217a34984e602b8461752c17600db5458a9
+            perl-Test-CheckDeps:
+                rationale: Part of the first base-runtime prototype.
+                ref: b234785ee88a57bd09bd51e0411ebc418e34b2d5
+            perl-Test-CheckManifest:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2bf399756bf3be52d7e375e1e8ce0e3b36638766
+            perl-Test-ClassAPI:
+                rationale: Part of the first base-runtime prototype.
+                ref: 840c9d38915b61ce33f35366f0f043a3c2f9bae7
+            perl-Test-CleanNamespaces:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6ec21f83c9ec87f24e56f92365cd8870701ac2fc
+            perl-Test-Compile:
+                rationale: Part of the first base-runtime prototype.
+                ref: c7aeba15048c1501a4982c4ab900ba87c52993ef
+            perl-Test-ConsistentVersion:
+                rationale: Part of the first base-runtime prototype.
+                ref: a14071644c3cad0c75a4fecb6a3455bb7ea8e1fc
+            perl-Test-CPAN-Meta:
+                rationale: Part of the first base-runtime prototype.
+                ref: e14443c87320d8b2fa21c543fe554fa774058c25
+            perl-Test-CPAN-Meta-JSON:
+                rationale: Part of the first base-runtime prototype.
+                ref: 55f6f561b1f3b40c6d7f246c1998e5d5265e0329
+            perl-Test-CPAN-Meta-YAML:
+                rationale: Part of the first base-runtime prototype.
+                ref: ffcdabb43b70dff9b5996d32e27600766aadf61e
+            perl-Test-Deep:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2888d52f96c7193a7f68e471e76f37f52e951f01
+            perl-Test-Differences:
+                rationale: Part of the first base-runtime prototype.
+                ref: 267d846ded028d44da8ec442b26b7601593e1820
+            perl-Test-Dir:
+                rationale: Part of the first base-runtime prototype.
+                ref: df32d7e617cc2f8bd1a733c411fbec97939a21bc
+            perl-Test-DistManifest:
+                rationale: Part of the first base-runtime prototype.
+                ref: d1645c706db0cd8f2681f21991a1864bbc438258
+            perl-Test-Distribution:
+                rationale: Part of the first base-runtime prototype.
+                ref: c5872a26f3e49591d996b558b1c97ee83cb9d1a6
+            perl-Test-EOL:
+                rationale: Part of the first base-runtime prototype.
+                ref: 643fc9efe0ab8942e202734e85c4dd730c2b0b8b
+            perl-Test-Exception:
+                rationale: Part of the first base-runtime prototype.
+                ref: a968edeb0fcc2e4faad1a58f9b081a3b01082e47
+            perl-Test-FailWarnings:
+                rationale: Part of the first base-runtime prototype.
+                ref: a0c1e94a1a488e7c565a6f837cc44d825563a62d
+            perl-Test-Fatal:
+                rationale: Part of the first base-runtime prototype.
+                ref: 91903ba6592f35961992ec9a8f97b9842f68f880
+            perl-Test-File:
+                rationale: Part of the first base-runtime prototype.
+                ref: a76569e5ed254e6d2a5a0d51a5aa3b6f3aee4d59
+            perl-Test-Fixme:
+                rationale: Part of the first base-runtime prototype.
+                ref: db0be47dadf1ecd8571b015c255bb595c60afd1d
+            perl-Test-Harness:
+                rationale: Part of the first base-runtime prototype.
+                ref: 876f451484b4cf68e840d31ba68f68f20bec94b2
+            perl-Test-HasVersion:
+                rationale: Part of the first base-runtime prototype.
+                ref: edfbcecd40960cf298efa16c95850f0b4e3c6588
+            perl-Test-Identity:
+                rationale: Part of the first base-runtime prototype.
+                ref: e1ff32137558d1ff06f7c413f03400f7c68273e0
+            perl-Test-InDistDir:
+                rationale: Part of the first base-runtime prototype.
+                ref: cba891365187aab6d0812d86201b03ec55fb8457
+            perl-Test-Inline:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8a9b55c6462995296ccf25032f87f041f256dc26
+            perl-Test-Inter:
+                rationale: Part of the first base-runtime prototype.
+                ref: 304b25840ac8f55115d2f3438c7c48b6e222c52b
+            perl-Test-Kwalitee:
+                rationale: Part of the first base-runtime prototype.
+                ref: a1034337283bdc8af318e6cfced49c2df4499607
+            perl-Test-LeakTrace:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0ef97ef3348fa06cee1e02d0654bb6587ca61e4d
+            perl-Test-LongString:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7ec0c7240db74acf5efe6b5d7536cb12af9c040e
+            perl-Test-Manifest:
+                rationale: Part of the first base-runtime prototype.
+                ref: b718abc6ff0ec7c8e4380ce53be37cf510713a84
+            perl-Test-Memory-Cycle:
+                rationale: Part of the first base-runtime prototype.
+                ref: e3120274bde7d70d3a6b426b1fe404ae95c13778
+            perl-Test-MinimumVersion:
+                rationale: Part of the first base-runtime prototype.
+                ref: 815a226e65741beb1ab6f61222795e312cb5d688
+            perl-TestML:
+                rationale: Part of the first base-runtime prototype.
+                ref: bbeee06e28affd31ce34d3bdb63a74e7413e9e8e
+            perl-Test-MockModule:
+                rationale: Part of the first base-runtime prototype.
+                ref: a5cc445dc33b80a8573392295fc854fb736f9afb
+            perl-Test-Mojibake:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0381374dc6b526f2ff2bc74f0282e5e698c5b3e4
+            perl-Test-Needs:
+                rationale: Part of the first base-runtime prototype.
+                ref: c45f4485d9e7089a5523f7a5f5d514964c6cf69b
+            perl-Test-NoBreakpoints:
+                rationale: Part of the first base-runtime prototype.
+                ref: dcb6fa7188b6f84a0e53d252e7d312d58164f6df
+            perl-Test-NoPlan:
+                rationale: Part of the first base-runtime prototype.
+                ref: f62ccddcbde7de2afe1e7915e9ba74dc91dbc47d
+            perl-Test-NoTabs:
+                rationale: Part of the first base-runtime prototype.
+                ref: e0f47a5d72fbb6c4c720660b256f99946c4a274c
+            perl-Test-NoWarnings:
+                rationale: Part of the first base-runtime prototype.
+                ref: eed36261732495a5a65239dcad52c699bea32d2b
+            perl-Test-Object:
+                rationale: Part of the first base-runtime prototype.
+                ref: e21546e1a20aa001453721a744680b65041da167
+            perl-Test-Output:
+                rationale: Part of the first base-runtime prototype.
+                ref: b5e16cfff4d0f0a73d846a6e49075529dbe17d35
+            perl-Test-Perl-Critic:
+                rationale: Part of the first base-runtime prototype.
+                ref: 02a8033850cb8b197f37afbcead76ec963058958
+            perl-Test-Perl-Critic-Progressive:
+                rationale: Part of the first base-runtime prototype.
+                ref: c7d29d0950f8e1759804fcfa2e1584704fd6adbb
+            perl-Test-Pod:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5bfabcde82c9afa892e9b48f0312bc6d5b6b7646
+            perl-Test-Pod-Content:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7d680f0d1e39468fec3fcb50913f78f210fa13dc
+            perl-Test-Pod-Coverage:
+                rationale: Part of the first base-runtime prototype.
+                ref: a0173fbd9945b9db6870fdbf0c2adab2a5092423
+            perl-Test-Pod-LinkCheck:
+                rationale: Part of the first base-runtime prototype.
+                ref: d362a82a7a9cc7a7a709343c70e14cdeb3a98539
+            perl-Test-Pod-No404s:
+                rationale: Part of the first base-runtime prototype.
+                ref: d8c3da1b5322b0bd5aa82ae3c393ea6ad6cebe87
+            perl-Test-Pod-Spelling-CommonMistakes:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1e7eb456bd4dc1068fd4c4049a46c1282f992e77
+            perl-Test-Portability-Files:
+                rationale: Part of the first base-runtime prototype.
+                ref: 76be0febd1c8e7148e1e5d73939caefe308bedf9
+            perl-Test-Refcount:
+                rationale: Part of the first base-runtime prototype.
+                ref: b3f9f76b772f1cac499ee06c094fb0a7525d0ff5
+            perl-Test-Regexp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8e0712c535082b44d3e9d0b1f98a945ead1fe24c
+            perl-Test-Requires:
+                rationale: Part of the first base-runtime prototype.
+                ref: d16adc46fbeb5a5b53de6e661875a276f0eb8256
+            perl-Test-Script:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3f55ea83ded27a54ce0832280d3139bf0bfd87f4
+            perl-Test-Signature:
+                rationale: Part of the first base-runtime prototype.
+                ref: 520b845188b180ed9d30b034f41758027a7554a8
+            perl-Test-Simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: 106da2f18d080f594b790d53f66cc7b9bcda2398
+            perl-Test-Spelling:
+                rationale: Part of the first base-runtime prototype.
+                ref: 76eaedc4b3a294c3e699eefb1fcb2347546d4c00
+            perl-Test-Strict:
+                rationale: Part of the first base-runtime prototype.
+                ref: f26869e4d037aeefaa9aec3f0af9299fb546ea99
+            perl-Test-SubCalls:
+                rationale: Part of the first base-runtime prototype.
+                ref: e032370bc78b4f1bc830d654138d8f69599cc155
+            perl-Test-Synopsis:
+                rationale: Part of the first base-runtime prototype.
+                ref: 817dbb8596ebe0b997571c333b669d48596beb9d
+            perl-Test-Taint:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0929ea00d98a08aa6eb0b3d4b6184ad611b117b2
+            perl-Test-TrailingSpace:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1171db761713e6fa3956a424c384b3b57c966d4a
+            perl-Test-Trap:
+                rationale: Part of the first base-runtime prototype.
+                ref: cf3f6269876329c2800eb03cb572171856132f9f
+            perl-Test-Unit-Lite:
+                rationale: Part of the first base-runtime prototype.
+                ref: a991946e9241ce4c0554cd8686a7cba474bc591d
+            perl-Test-UseAllModules:
+                rationale: Part of the first base-runtime prototype.
+                ref: 54d4cab683bbc6fc2e8ff575214656ad4fd2b750
+            perl-Test-utf8:
+                rationale: Part of the first base-runtime prototype.
+                ref: 24c185d2bee0fae9f7ff55e17e87386a6974c208
+            perl-Test-Valgrind:
+                rationale: Part of the first base-runtime prototype.
+                ref: 21a1111f91066135688a25971cf57ac89d8617e8
+            perl-Test-Vars:
+                rationale: Part of the first base-runtime prototype.
+                ref: e8e96699a2f72bb438c3bf3c828e19366f139213
+            perl-Test-Version:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6abb53a97a26f3c253216f32292d3c82e52d759e
+            perl-Test-Warn:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8645b3a41f30ee02b0201fe0c59d86cb69e699b7
+            perl-Test-Warnings:
+                rationale: Part of the first base-runtime prototype.
+                ref: b1615f51bfdd496ccfd3c5d8c647f27de5acc484
+            perl-Test-Without-Module:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2c1abcc30aeb3a342bba959c541bc879518148eb
+            perl-Test-YAML:
+                rationale: Part of the first base-runtime prototype.
+                ref: b60d56f6fb17578bca84bb04ac1304cd1f4eadff
+            perl-Test-YAML-Valid:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7568f721c251d4f42e731359660c51ff89e4d8a9
+            perl-TeX-Hyphen:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1166a58e8723e4ae69806846b651c364292ccca0
+            perl-Text-Aligner:
+                rationale: Part of the first base-runtime prototype.
+                ref: e21383e887a457cd4acc306ad31f1aa8467eabfa
+            perl-Text-Autoformat:
+                rationale: Part of the first base-runtime prototype.
+                ref: f9fad795611843f8d39d30cb2496953f2e2221ea
+            perl-Text-Balanced:
+                rationale: Part of the first base-runtime prototype.
+                ref: 197d2cbe62cb328b57291af59495d03bf80b7a57
+            perl-Text-CharWidth:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2a1a10494ce195e13a37f8d1ce695d35497e7038
+            perl-Text-CSV:
+                rationale: Part of the first base-runtime prototype.
+                ref: e131a7e054ae5397c1ac8e3f7d6271e6b67613ea
+            perl-Text-CSV_XS:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3d3b59c45b74ef7bb62b28ab9fe12115b616e9e6
+            perl-Text-Diff:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1c90749fc36c2c3e1dec2b44cd64053ccc706648
+            perl-Text-Glob:
+                rationale: Part of the first base-runtime prototype.
+                ref: 304cfdbf72f63c051869a112f25906598b6edf80
+            perl-Text-Iconv:
+                rationale: Part of the first base-runtime prototype.
+                ref: ac0f1d6912d9c5bf92d94b2edb4be8e6b7728c8b
+            perl-Text-ParseWords:
+                rationale: Part of the first base-runtime prototype.
+                ref: e3a8ecad34cb82d4698df2195ce26e6a9115121c
+            perl-Text-RecordParser:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4d999447b8f0289c38e10c182aa85c26e980749f
+            perl-Text-Reform:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7d5b1c49f2cbeb3246965954174fa53a32cfc669
+            perl-Text-Soundex:
+                rationale: Part of the first base-runtime prototype.
+                ref: 68fbb4cb08e1d60c30106b1fa8f35c2c91780e88
+            perl-Text-Table:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1d15de6ea5d7dcd53c08d474b2e812641bcad073
+            perl-Text-Tabs+Wrap:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1715b1a7dc66e6e0434fd29672852dce61122e56
+            perl-Text-TabularDisplay:
+                rationale: Part of the first base-runtime prototype.
+                ref: c32282aeae90a74db2d0584b489a33548e8440bf
+            perl-Text-Template:
+                rationale: Part of the first base-runtime prototype.
+                ref: 230219fc98607b30003abe6b53f46277fa2036a7
+            perl-Text-Unidecode:
+                rationale: Part of the first base-runtime prototype.
+                ref: 40c2a339a9a8759d7b27bfc757bdef2ec7153ed7
+            perl-Text-WrapI18N:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4050eab7de7c8d66b4a572d748118681d00e9f36
+            perl-Thread-Queue:
+                rationale: Part of the first base-runtime prototype.
+                ref: e8af63c6c50168374d02c6adc1c78abd6d3c46ce
+            perl-threads:
+                rationale: Part of the first base-runtime prototype.
+                ref: 57e488d5a65ad2e3cf24fd9701ee3c3e544cde4e
+            perl-threads-shared:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6ca093a5a706697c4427f9953d1bc9b4e06c2f9d
+            perltidy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1a3621f616723e9085b08e1852c5432dd22b2537
+            perl-Tie-IxHash:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0fa5d8ddb329e240873e9b34e44b337b9bd8fbb5
+            perl-Tie-RefHash-Weak:
+                rationale: Part of the first base-runtime prototype.
+                ref: d2d22547dd05a8c520c046db9a1ebe8d435a710c
+            perl-Tie-ToObject:
+                rationale: Part of the first base-runtime prototype.
+                ref: a83380f5ebb8ab2e2b81dbdb4b3d3f63185b43f2
+            perl-TimeDate:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7fade5b10855389bf023ce36f53f77286208b87e
+            perl-Time-HiRes:
+                rationale: Part of the first base-runtime prototype.
+                ref: 584b597158e8c02f954195b76ce242ec4c3adff0
+            perl-Time-Local:
+                rationale: Part of the first base-runtime prototype.
+                ref: 997c51f42d3dfc332707e5b4b8da682cb8e40b09
+            perl-Time-Piece-MySQL:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9a7f916edc5c9acadff544b8b477dd4a76667f21
+            perl-Tk:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3f9d104cf28f01d322034f3206fb55cb10865f69
+            perl-Tk-Pod:
+                rationale: Part of the first base-runtime prototype.
+                ref: de6a15aa27e690db7ae6ec7cea2c3c89ca92504a
+            perl-Try-Tiny:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1939af56d72a2c6094cfa9d22fbc4e8c7e8e10a3
+            perl-Types-Serialiser:
+                rationale: Part of the first base-runtime prototype.
+                ref: 17189fe55f44fc06f23c60512776affbcfb44452
+            perl-Type-Tiny:
+                rationale: Part of the first base-runtime prototype.
+                ref: e2a4deee12ffb45f79fffa65e43e8812af8ca7c4
+            perl-Unicode-CheckUTF8:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4f877d4c071ae2e7a035a1d9d9cb4f2ebf88a0b8
+            perl-Unicode-EastAsianWidth:
+                rationale: Part of the first base-runtime prototype.
+                ref: a1ec3b637315e65b3fb0b688bfb1edb8d99f7edc
+            perl-Unicode-LineBreak:
+                rationale: Part of the first base-runtime prototype.
+                ref: e878d7b3c68e6d11dac398f1d70ca281cc88766a
+            perl-Unicode-Map:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4b38be1afe3abf7f62cd88caf9a841eaaf8150a3
+            perl-Unicode-Map8:
+                rationale: Part of the first base-runtime prototype.
+                ref: cf06d41efe39f011f6d9bb15e584a748e52b853c
+            perl-Unicode-Normalize:
+                rationale: Part of the first base-runtime prototype.
+                ref: dbd18c4ff2465f8b2fd88c1fd6d366eff6d2d4ea
+            perl-Unicode-String:
+                rationale: Part of the first base-runtime prototype.
+                ref: bb04e30cf7b50a9199db9e8732bf09ff03443491
+            perl-Unicode-UTF8:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1ccb46094c3583d37b62f81788248db976174661
+            perl-UNIVERSAL-moniker:
+                rationale: Part of the first base-runtime prototype.
+                ref: fd4be25d973afe40d18fbe0f8eae7082cbf0541c
+            perl-UNIVERSAL-require:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2228a850fe4ad4e9fab5837ff197c324eaaf0455
+            perl-URI:
+                rationale: Part of the first base-runtime prototype.
+                ref: c89b6346fce383d05aba97584797cac28d118d47
+            perl-URI-Find:
+                rationale: Part of the first base-runtime prototype.
+                ref: e1807c5bb60048410b494ac3e9c0938f1601de0a
+            perl-utf8-all:
+                rationale: Part of the first base-runtime prototype.
+                ref: da8b70fc93aec54fbdc61e1f3c50becb9769179e
+            perl-Variable-Magic:
+                rationale: Part of the first base-runtime prototype.
+                ref: abcea79fdb4c042747c0d65b676e11b6de2eb30e
+            perl-version:
+                rationale: Part of the first base-runtime prototype.
+                ref: 57058d1c59f4886ea4989b6fd1f235dca110555a
+            perl-WWW-RobotRules:
+                rationale: Part of the first base-runtime prototype.
+                ref: 224bbb0c9ad22228e4a2c0a28b70bf81ed3c6a45
+            perl-XML-DOM:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4adf407e899e00f0d5863db21c915d5e1d1147ac
+            perl-XML-Filter-BufferText:
+                rationale: Part of the first base-runtime prototype.
+                ref: 12df179eca4e5856015b2238e81ec465581dfd72
+            perl-XML-Handler-YAWriter:
+                rationale: Part of the first base-runtime prototype.
+                ref: 05521ade61a4ec84c4284b897935d97e2d41638c
+            perl-XML-LibXML:
+                rationale: Part of the first base-runtime prototype.
+                ref: 697b968da967f4a01a1f09d33edf41746cc85996
+            perl-XML-NamespaceSupport:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9f9ba6964dee3f9f5653ff41b4165aa74b967f88
+            perl-XML-Parser:
+                rationale: Part of the first base-runtime prototype.
+                ref: d72af3e2a66e770ad148f77778d1d1cd93fa0546
+            perl-XML-RegExp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3705333f0b3b91f9004fcdc20a9d369bb8b2b843
+            perl-XML-SAX:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6c0cb9fe76b7f66342b9c2111ea4ddf98fb6e288
+            perl-XML-SAX-Base:
+                rationale: Part of the first base-runtime prototype.
+                ref: a1cf06611208a9489dec061c6105b0805eddc7e2
+            perl-XML-SAX-Writer:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1527c785191b5bc5edbbac786bdeeab21aa6ee37
+            perl-XML-Simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: d505868c3ad3a6d3f3c3deb05e2fc39f455ab4bf
+            perl-XML-Twig:
+                rationale: Part of the first base-runtime prototype.
+                ref: c6275a178c0cfa6218575b3e08e7755ce6388cf8
+            perl-XML-Writer:
+                rationale: Part of the first base-runtime prototype.
+                ref: 80b3dfd953d755958df2440f3243938aae924851
+            perl-XML-XPath:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3c2deaeb90898e751a1efa51ce923737c5155ff7
+            perl-XML-XPathEngine:
+                rationale: Part of the first base-runtime prototype.
+                ref: fca5503c3f72a6b9f37797ea3d3c0a55e0f46276
+            perl-XXX:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5d8c1a936a711c86c6eef323cb6cda0b98f6843b
+            perl-YAML:
+                rationale: Part of the first base-runtime prototype.
+                ref: 452f0876687cea602cd1551af00500c44441df78
+            perl-YAML-LibYAML:
+                rationale: Part of the first base-runtime prototype.
+                ref: 40d37e317fb08dd588ce2034a8139c44d2b71e9d
+            perl-YAML-Syck:
+                rationale: Part of the first base-runtime prototype.
+                ref: e108068cab174f9f146c559dcad493a1f0e60d72
+            perl-YAML-Tiny:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94a099d7dc6d3b6266df66ee7a836f02f77a8820
+            pesign:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4677d7067ce34e7aa25a7ef7a474c2c633306467
+            phonon:
+                rationale: Part of the first base-runtime prototype.
+                ref: 27622033519b33aa843ce4cbf332a142eb23f3f8
+            phonon-backend-gstreamer:
+                rationale: Part of the first base-runtime prototype.
+                ref: 678b3d788a102254c305c9fb46467bb1ff4d7d13
+            php:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7695a7f8d0a80a972fe032d9b24421e81c10e6e2
+            picketbox:
+                rationale: Part of the first base-runtime prototype.
+                ref: ab8df9d2f8dece1f6292a033ab5efa334b73240c
+            picketbox-commons:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8e1d6efc0de3d354dc6cc0884684db883d745ed4
+            picketbox-xacml:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8b167b349aeb5542381cc0350709cb74e3d3058d
+            picocontainer:
+                rationale: Part of the first base-runtime prototype.
+                ref: bb35d02705a31045f8dd33e4a54a072bc9d0c38c
+            pixman:
+                rationale: Part of the first base-runtime prototype.
+                ref: a4578fa5bdfc70bbc7994852392517dd93312acf
+            pkcs11-helper:
+                rationale: Part of the first base-runtime prototype.
+                ref: f9a65385f48ecefa6a8dc609297926fe0d780df2
+            pkgconfig:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2db724c7c80fe3c457403aef173e866807f7d89d
+            plexus-ant-factory:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5039ac899c1ee7318ba7c65d53f2b1b32664a953
+            plexus-archiver:
+                rationale: Part of the first base-runtime prototype.
+                ref: 46c3871a35f22ee9aa5e17a4bcd78536e0b90aac
+            plexus-bsh-factory:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1d2e8938295b000caab17645944291ec21ff761a
+            plexus-build-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94ec0ca43b135073520ef368b47ccf5f77313e1a
+            plexus-cipher:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7fc952c4b1de472c54445891fb3206950bbb7895
+            plexus-classworlds:
+                rationale: Part of the first base-runtime prototype.
+                ref: 413f83c9d7b1cb59a70c47c72aa70f3d8874a0a3
+            plexus-cli:
+                rationale: Part of the first base-runtime prototype.
+                ref: 236f2b12ec19b98300eb82754647492174cbec13
+            plexus-compiler:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8353762e5927756548b1c22aca90efe40ed32601
+            plexus-component-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94c300a89d38de217142a45b06e60633ca9c531e
+            plexus-component-factories-pom:
+                rationale: Part of the first base-runtime prototype.
+                ref: c22be08b782b9a19c8e6d5ce93d8c6c4874a13ab
+            plexus-components-pom:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4a09cbd4bb60064a5a41ba25d97b8bce025b7eb1
+            plexus-containers:
+                rationale: Part of the first base-runtime prototype.
+                ref: d8ae4b0cb054f82c6fcef8cf2d8fa18bd27d31e5
+            plexus-digest:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8e4862ca5449de3f8118efe454773d1cb88f5d41
+            plexus-i18n:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0b2021df87160b90641395a96e1ffd4dfb57308f
+            plexus-interactivity:
+                rationale: Part of the first base-runtime prototype.
+                ref: 301fbcc97197e2afb807e022a8bb15a42d858f13
+            plexus-interpolation:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4765179d377c59491feaf4e77c895f8d0e652936
+            plexus-io:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5dcb553314dc03826a52b7242f30ec4f8fc4ea24
+            plexus-pom:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0c491367506c00efe803db420444edb34c11c633
+            plexus-resources:
+                rationale: Part of the first base-runtime prototype.
+                ref: a00ab615bbba099eca11bc28ca7e86fd9d69d8f1
+            plexus-sec-dispatcher:
+                rationale: Part of the first base-runtime prototype.
+                ref: ae415acacf346571803f15ca934f84efdec778f0
+            plexus-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 21b92c7f386bd0bbfc6b314a61a2c12691a0f035
+            plexus-velocity:
+                rationale: Part of the first base-runtime prototype.
+                ref: b72bbbc09d66bfa398bd8c49abc61e92d7c471c8
+            plotutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8547c402bfc21b378ff8e446287bd6823c7a9193
+            pmd:
+                rationale: Part of the first base-runtime prototype.
+                ref: 31b813f00216480c397991c6dd1b5f675f581692
+            pmd-build-tools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 937c47d268d5eb09c51f4a0f48679bc6ad0eb9e6
+            po4a:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3feceacc6adf6a687d0f0d469e4dee199a5a2063
+            policycoreutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1888063970ea811b4198c8f8321960a7e8bbf31a
+            polkit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 72449739ab29ae0e5849fa0245976694b15ad7a6
+            polkit-pkla-compat:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0d06208003cead28f10c143f2dbcfa6118268ed8
+            polkit-qt:
+                rationale: Part of the first base-runtime prototype.
+                ref: c7808076e97ea8fcada70d32df21b4800bbd321d
+            poppler:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9560bc93e0cbee88b44b5e9d2fa16ff61a900f36
+            poppler-data:
+                rationale: Part of the first base-runtime prototype.
+                ref: 840f5650140204326a92433371f1735f9bbd4095
+            popt:
+                rationale: Part of the first base-runtime prototype.
+                ref: c9a8418c0799b9135e9d0a6ea57e7d4517550416
+            portals-pom:
+                rationale: Part of the first base-runtime prototype.
+                ref: a13b6ed30f5757a9c7e84cfc3f354bad3be05782
+            portaudio:
+                rationale: Part of the first base-runtime prototype.
+                ref: 34be1a1c389ea68f022c0a1f44fe77e9f3da5b65
+            portlet-2.0-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: be2abe0e1c0af85ed62a056095a5430c9e221998
+            postgresql:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5239ac0d0fc6bb40598d4ab938b23a3a0b91954a
+            postgresql-jdbc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5b7e5e07b5558673688488deb3e7544bfbfc4178
+            potrace:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2b672d1f734820e00c20bd87ca428185f7913fd8
+            powermock:
+                rationale: Part of the first base-runtime prototype.
+                ref: f2ffd0d0c3f9707bcc41b3c5b6c87c2859927d84
+            ppp:
+                rationale: Part of the first base-runtime prototype.
+                ref: d314a193412ad10497b40cc01efa00b41426c754
+            procmail:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3d5897c851db9cb2f27f78f6d99a26279759fdaf
+            procps-ng:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7b0213a3bc42e5a28e4e44f4d3281070cef88039
+            proguard:
+                rationale: Part of the first base-runtime prototype.
+                ref: ede3ce3afa356050a5b17574ca905ca3a5c5ea6e
+            proj:
+                rationale: Part of the first base-runtime prototype.
+                ref: fd805ca5290abb83bcc6be6c97e1b385e0a2cfaa
+            properties-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0697641ac297809322c41ad112237be26809962a
+            protobuf:
+                rationale: Part of the first base-runtime prototype.
+                ref: 475975c011aa2d77ea961a466a085fa4b23f5cec
+            protoparser:
+                rationale: Part of the first base-runtime prototype.
+                ref: 43c93012bbb1dcbe36c0f95cae74f2923f26e7cf
+            protostream:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4113b554c42f09df852897834d48f574b02c5066
+            proxool:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8ab07845f473f3f2b6d084c17feaa1cf00f50007
+            psmisc:
+                rationale: Part of the first base-runtime prototype.
+                ref: adc4e64007e99b56ba825a9a406b17d461e77a58
+            pstoedit:
+                rationale: Part of the first base-runtime prototype.
+                ref: d454dec3031868026340e6b31819045c196b86e4
+            psutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: fe97e8c65d9e5f2f2617be05193c16424c207d39
+            pth:
+                rationale: Part of the first base-runtime prototype.
+                ref: ca84dbeaa0c92511ee748ed066aec09917580fd8
+            publicsuffix-list:
+                rationale: Part of the first base-runtime prototype.
+                ref: e82d0866945ffcbe77b15bc41d59170908375dbc
+            pulseaudio:
+                rationale: Part of the first base-runtime prototype.
+                ref: 31435d42db016b78736dc0c941086344abbd0380
+            pycairo:
+                rationale: Part of the first base-runtime prototype.
+                ref: c5502c9b67622d4ad638e3423aff5d5c4df396c5
+            pycryptopp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 40e1508cf240987fad7261ffc8ce17640ec76938
+            pyflakes:
+                rationale: Part of the first base-runtime prototype.
+                ref: 39ffa67ee51ddf1df95e6a305dfedc0815c683b6
+            pygobject2:
+                rationale: Part of the first base-runtime prototype.
+                ref: cd2d9353f8fe7323d0029498a8a0394c4a98048d
+            pygobject3:
+                rationale: Part of the first base-runtime prototype.
+                ref: acd45ef7ed9123fac21961f810c39019922ab1b9
+            pygtk2:
+                rationale: Part of the first base-runtime prototype.
+                ref: d3f5e89205c358e588aae8e9b7c06b72648bf9a3
+            pyliblzma:
+                rationale: Part of the first base-runtime prototype.
+                ref: 67df130e85e40aefdabfc8991c3a159f65df9658
+            pyOpenSSL:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2d786ca26e5325955bd78ee8264b0006a538c616
+            pyparsing:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9ce1ef4116db6ecb7f4be7d66f8d985a792dc5db
+            PyQt4:
+                rationale: Part of the first base-runtime prototype.
+                ref: a70467234b74f31d0355e853f1d2a3ada14621d3
+            pyserial:
+                rationale: Part of the first base-runtime prototype.
+                ref: e5bd999c12bbd775eb7f92338fb54a5b4d6175d0
+            pytest:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1254ebc9c4579f76472f6e73196d5cba667adb7c
+            python2-typing:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5d5e5b21b4fe8ab8d118dea4e04db69d6d31d04c
+            python3:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1768987fbca92f1ea4820046c3f294c8b50ec949
+            python3-cairo:
+                rationale: Part of the first base-runtime prototype.
+                ref: ba49479f76b2d30a2eb53327d4ac86d9b3eae8aa
+            python3-mallard-ducktype:
+                rationale: Part of the first base-runtime prototype.
+                ref: 773b972eb11439c31d4f068e0d86d7bf3aa06065
+            python:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9b77cb62b4f483d6b7130403117d3140fb71e9bb
+            python-backports_abc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 81b31c9eaf7ee68c63a3572769dbd3f440926925
+            python-beaker:
+                rationale: Part of the first base-runtime prototype.
+                ref: d37e83c916f9fdfc9220fbb2430c45bcac849889
+            python-beautifulsoup4:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4864c3a6bcb6971fa127cbc5d471ca352d95369c
+            python-BeautifulSoup:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7b42402ec59c8f71b39a6599ed76b0db656f6e0f
+            python-bottle:
+                rationale: Part of the first base-runtime prototype.
+                ref: fc3fb870b82ef20bcbf0990d987b5e4a77f340fb
+            python-bugzilla:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6abff2208d1c66ebac36795089ded846c1bd6de3
+            python-cffi:
+                rationale: Part of the first base-runtime prototype.
+                ref: fdcd11f4ed27a045655cfc43d13b32c8d05568ac
+            python-characteristic:
+                rationale: Part of the first base-runtime prototype.
+                ref: 04d8b9c84b08358a38bc6f2c872e35ced588a8c3
+            python-chardet:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9973efd3a81ce6ed2ac9053b1dc03dea1c065ac2
+            python-cliapp:
+                rationale: Part of the first base-runtime prototype.
+                ref: fe482b54707138b3f6b66e02ee9052278f4cc745
+            python-click:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5398fc8bd9dd40a8867a7b507bc50765d08b056e
+            python-construct:
+                rationale: Part of the first base-runtime prototype.
+                ref: 408ac74da86fdc818c69891a492ab41b6158130c
+            python-contextlib2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6caedc98d6292ca5cd097174d9f6d48bbdf698b4
+            python-coverage:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9c808d5a7d5bc8f0de1b85267567d2eb19657f7c
+            python-coverage-test-runner:
+                rationale: Part of the first base-runtime prototype.
+                ref: 25d61507b1d06ca1ddcfb616d1c7c8cd70427ad0
+            python-crypto:
+                rationale: Part of the first base-runtime prototype.
+                ref: c85c62d5aa929a9a4cd69d18d02e99848569c631
+            python-cryptography:
+                rationale: Part of the first base-runtime prototype.
+                ref: 176e84e1af96af16f48af6bafcdcc0c5852e71ac
+            python-cryptography-vectors:
+                rationale: Part of the first base-runtime prototype.
+                ref: 585d2077ff4720a20d8c060bec91528a40145976
+            python-cssselect:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2a8752980b29eac43d84216036cc62a110c1db31
+            python-cups:
+                rationale: Part of the first base-runtime prototype.
+                ref: c34977f23f665cafd76057a150833fc2e53e0a44
+            python-dateutil:
+                rationale: Part of the first base-runtime prototype.
+                ref: f6b3f930460340f9bfef32efc93802343267bba2
+            python-decorator:
+                rationale: Part of the first base-runtime prototype.
+                ref: 726486d0879790f99f56cc0d0d8cbd3512124094
+            python-docutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: fe33132bdff5ba8fd10232d81cb9963478870596
+            python-dtopt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7fa3855d444c8bc829a561fd4e2df684424a0a3c
+            python-empy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3cdc0c09b6d9c60373dd01ed44e61e0a491400c4
+            python-enum34:
+                rationale: Part of the first base-runtime prototype.
+                ref: 258134197fd2d0867e99e4acfee57af2d455e0a0
+            python-extras:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2c14625db6c52e61bc382f0a5a6a7281820ee5b1
+            python-fixtures:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0ad0dda0541290df47c6448df3ad94cc33236c39
+            python-flask:
+                rationale: Part of the first base-runtime prototype.
+                ref: a3ca7e011729f1c5b987cb8d3b80ee2e4e7a0639
+            python-funcsigs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6fad77f8c32f94e98d58c2eac7ebaa50fa043a44
+            python-gflags:
+                rationale: Part of the first base-runtime prototype.
+                ref: 481cc703a738a9081c0b9638779e1c0ba3aabdec
+            python-google-apputils:
+                rationale: Part of the first base-runtime prototype.
+                ref: f379910add141ca9de0c7bda690dc82fb54db9b6
+            python-html5lib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5140d18684831bb4b4fa9751a89373ec9bc22e17
+            python-http-parser:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2a5b04c034ab120bac1bbb53dc2737049bd64589
+            python-hypothesis:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4ae1a6726fb1b83afaaea376192357c1305b8ad1
+            python-idna:
+                rationale: Part of the first base-runtime prototype.
+                ref: e2ebb4f0f92971eb1c68a1391a7949c7a96791ec
+            python-imagesize:
+                rationale: Part of the first base-runtime prototype.
+                ref: 01dce3aaa73a377c21c879e62602da58b890cfa7
+            python-iniparse:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2aa2eaf8ec6d4eb299adb4e6dec5e2d6f408ddca
+            python-ipaddress:
+                rationale: Part of the first base-runtime prototype.
+                ref: b13227a382b7bf69d69922fbb41b045e8d48d59e
+            python-IPy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 76163ec3676f319c3f709bbc41fd303e3e968243
+            python-iso8601:
+                rationale: Part of the first base-runtime prototype.
+                ref: f9a58c0982e00ae39313305ce2dd52c4dd350615
+            python-isodate:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7653ca2d60737cb22c2d373dbc80e443c9e5e216
+            python-itsdangerous:
+                rationale: Part of the first base-runtime prototype.
+                ref: 896cf407c30e42eaa8bee6a55ae5311cfe34852a
+            python-jedi:
+                rationale: Part of the first base-runtime prototype.
+                ref: aed336307488112c5f6a1e0245e4718c040a1301
+            python-jinja2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 62d3143b313cbf23f08fdf13e945c67abd62df5b
+            python-jsonschema:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8565f12fece8b3aa4dc5b42f319e07e6bba6852c
+            python-keyczar:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7351d1b07df1d6761d66aa570aecc6d69d16a6c2
+            python-keyring:
+                rationale: Part of the first base-runtime prototype.
+                ref: 004dc39e0ec62da75240e2dd7681658faadd7de6
+            python-linecache2:
+                rationale: Part of the first base-runtime prototype.
+                ref: ea6ca3ee0e370e1f01c85aad1b75dfa97b1ef26d
+            python-lxml:
+                rationale: Part of the first base-runtime prototype.
+                ref: f61642a334756d87c11d09be8bf1e2c0e74eacd7
+            python-mako:
+                rationale: Part of the first base-runtime prototype.
+                ref: d16cb7e2cf5cf9a0e11182722d83b756558a8a48
+            python-markdown:
+                rationale: Part of the first base-runtime prototype.
+                ref: fc2127f6cd4de0bacba654fcdc5366fc70daabd3
+            python-markupsafe:
+                rationale: Part of the first base-runtime prototype.
+                ref: 39dc1400e2041bd8b6639726aaa45c960c3ea06e
+            python-mimeparse:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5c32d29f717166c2c821eb6e40928b2a0e41d0b1
+            python-mock:
+                rationale: Part of the first base-runtime prototype.
+                ref: 02cd15ab20d4567427435c511e43272816ef1b97
+            python-mox:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1a9dd4e3bbb4a1193bd31aefe93a0cafa983221d
+            python-netaddr:
+                rationale: Part of the first base-runtime prototype.
+                ref: a967f062b95218221ef703beee27c21aded18eb3
+            python-nose:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7539d24f324189642b704468fef259692e40833a
+            python-paste:
+                rationale: Part of the first base-runtime prototype.
+                ref: 517dd5c15652d56f98b69528c0e7d1044cd00628
+            python-paste-deploy:
+                rationale: Part of the first base-runtime prototype.
+                ref: ce616bb45f9c24438249a51ea26afe95b813fbcc
+            python-pbr:
+                rationale: Part of the first base-runtime prototype.
+                ref: f53e4c67d1125a61f611034796a48781e2697170
+            python-pep8:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8a960e48197458b31b6796a2fb74820dfff08027
+            python-pillow:
+                rationale: Part of the first base-runtime prototype.
+                ref: eee8c28520d8bdf872f023d9215e360462ca67d0
+            python-pip:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4841a130cb7f00a33a31c55c91abf1ac5997aa4e
+            python-ply:
+                rationale: Part of the first base-runtime prototype.
+                ref: bf2103776ec1bf02a718d9772cfedc1c64fd362f
+            python-pretend:
+                rationale: Part of the first base-runtime prototype.
+                ref: 97e0f0efde4854352773686863d391426996c375
+            python-py:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5c2af0b1c22534642a451b8120316cc8af593c5f
+            python-pyasn1:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9fb6f5135770e918ef06f40b7b8be36e00b59840
+            python-pybeam:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6f5605bea2837e92bd22c11eb599b95a41cf0ffe
+            python-pycparser:
+                rationale: Part of the first base-runtime prototype.
+                ref: f65b993f17669b1c6383b655027f4264dc48519f
+            python-pycurl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 79e3dcadb547e3a3a9784f06eb4b64c967588925
+            python-pygments:
+                rationale: Part of the first base-runtime prototype.
+                ref: 88102efeff967fa461de1795c8f2210d93116354
+            python-pygpgme:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6fb89f82fd47fe0d35a6118e030c50f28d464fe1
+            python-pyquery:
+                rationale: Part of the first base-runtime prototype.
+                ref: a47011b07d4b29ee11248901b078415231fd3584
+            python-pyrad:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3327e43f0cd6510fa7312576f2d090dc9f65afd8
+            python-pysocks:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8ec21d6f775bf72f6dca0f1292d57a0ad1b34ad1
+            python-pytest-timeout:
+                rationale: Part of the first base-runtime prototype.
+                ref: f00599415cba89eaa689d912862f82c949ebc4cf
+            python-pyudev:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9e299f24f6cd7bb5ad1608c6b31ef6bad3a6a2d9
+            python-qt5:
+                rationale: Part of the first base-runtime prototype.
+                ref: c511c76c20764a424403aae9d5f3840300c585c7
+            python-rdflib:
+                rationale: Part of the first base-runtime prototype.
+                ref: a729fa39fca6d0fe7133f740afb67fd2559d58ce
+            python-reportlab:
+                rationale: Part of the first base-runtime prototype.
+                ref: fa9647c27e34a45b91c846af7fe77e256683a631
+            python-repoze-lru:
+                rationale: Part of the first base-runtime prototype.
+                ref: 38ff08f1337534c17f1a7ed7853d174375943b96
+            python-requests:
+                rationale: Part of the first base-runtime prototype.
+                ref: c5ce60bf5a5f0a3a8d4e136484d300f76b025377
+            python-restkit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 179bbbf2f38f4b35562852a2137e3e541de5d639
+            python-rpm-macros:
+                rationale: Part of the first base-runtime prototype.
+                ref: 81fee785df7a63e04aa22d1571df38a393cd469d
+            python-service-identity:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8dfa5c50614db9fb1aa6b831cca1cc351cfcf32e
+            python-setuptools:
+                rationale: Part of the first base-runtime prototype.
+                ref: cfc5033eed198139323bf771f83b66f4b64e0636
+            python-setuptools_scm:
+                rationale: Part of the first base-runtime prototype.
+                ref: ab2e3d24d8efe05e8b910dbd0ddca388435ac15d
+            python-simplejson:
+                rationale: Part of the first base-runtime prototype.
+                ref: d7ee214f8ebf3e380a53d608dbe8a621aa1ca1f3
+            python-singledispatch:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5eec1428242f16c608dfdd83c1cd0b039f18a808
+            python-six:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2164b101ab0fd73406180a57255d30a2199eb346
+            python-slip:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2f5674961d03c1125968866763fb21526307a5a9
+            python-snowballstemmer:
+                rationale: Part of the first base-runtime prototype.
+                ref: a33b95f8b79f94897d75c890a0fdd2f2453d7290
+            python-socketpool:
+                rationale: Part of the first base-runtime prototype.
+                ref: fe9d07deac73fe97a87934a62de22d7757a89c6d
+            python-sphinx:
+                rationale: Part of the first base-runtime prototype.
+                ref: 80e09a56e7e9b931cfd9972cfc1fe4c540ab828c
+            python-sphinx_rtd_theme:
+                rationale: Part of the first base-runtime prototype.
+                ref: 27ebc03c9a30b180addab7ad9fafd60257574888
+            python-sphinx-theme-alabaster:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5085dedbc119dfb0507261d2f5f70e8a6e139f55
+            python-sqlalchemy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 92c65a57376b99c4d10b4bf902fe4804b4f2f749
+            python-systemd:
+                rationale: Part of the first base-runtime prototype.
+                ref: ed510fa26254dc67cf459ffa16c9c69ec828b11d
+            python-tempita:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7b0be0077de8b7cba5cc8b0fefba5e0e22c0280e
+            python-testscenarios:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2d31037551d1c7c885a743f413e59627e644e49f
+            python-testtools:
+                rationale: Part of the first base-runtime prototype.
+                ref: ed11b9bb4eaacefcaea87d5351c4dfabdae2e18a
+            python-tornado:
+                rationale: Part of the first base-runtime prototype.
+                ref: ffb114a0bacd05299990fb5e1ad2e02f86f4dbe2
+            python-traceback2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7fa9509c1761fa65a45755089fd570ebf9e74ec7
+            python-ttystatus:
+                rationale: Part of the first base-runtime prototype.
+                ref: 200d6cad8c867e044728ff1dad4122b1f857a569
+            python-twisted:
+                rationale: Part of the first base-runtime prototype.
+                ref: fa1883ca8f41b3b2866f0e7f4d764fc32a630d12
+            python-unittest2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7499ed35571124c216bb0d3d6d8edf79ed9609cc
+            python-urllib3:
+                rationale: Part of the first base-runtime prototype.
+                ref: bc86150b0ad1219062eac9568ac78ad457fb5cc1
+            python-virtualenv:
+                rationale: Part of the first base-runtime prototype.
+                ref: 404cde77b97041aac1bfd1014d516d08041b4f5c
+            python-waitress:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2f4c1ebcbb99e5c7c9982fe6a22ea882333caf98
+            python-webob:
+                rationale: Part of the first base-runtime prototype.
+                ref: c7ad26096554da5ccf083ab8c5df06c64bfc3025
+            python-webtest:
+                rationale: Part of the first base-runtime prototype.
+                ref: abdc5dd396bc3bd6e91f6f64f1101849265b67d6
+            python-werkzeug:
+                rationale: Part of the first base-runtime prototype.
+                ref: 952c99e4d4b2b3689063e3d74ec1641ed837fd80
+            python-wheel:
+                rationale: Part of the first base-runtime prototype.
+                ref: c1dfde25f0df0f1d6a33c500dbbed3fa2d115e1a
+            python-which:
+                rationale: Part of the first base-runtime prototype.
+                ref: a1b4b7c38f8a42ac9e9e883ef669100b9f9b4e32
+            python-whoosh:
+                rationale: Part of the first base-runtime prototype.
+                ref: 63dcb773cc5c8be095ddb23aa3cc0d7fa6c100a1
+            python-WSGIProxy2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 918faa26b0133f35931bd70b5d508529f927c0fd
+            python-xpyb:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3a480ecaa80e29eed03377d494eaf21aa3404684
+            python-zope-event:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0f6f38989e934a8b8d5842d03c6bb34c24eda3c3
+            python-zope-interface:
+                rationale: Part of the first base-runtime prototype.
+                ref: 96028d95786af0a6b784ff3865b089d15533f243
+            pytz:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8686bd9e2772ce03a24abc9b9727a435328b7c67
+            pywbem:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3b7439daaab3ef527c1c101932a657eb722f5390
+            pyxattr:
+                rationale: Part of the first base-runtime prototype.
+                ref: 27a38482a58800f35616731f2553f4e5bd360ded
+            pyxdg:
+                rationale: Part of the first base-runtime prototype.
+                ref: fcb3b4739b88b9ec549eacdbb00f816d38a8cfcf
+            PyYAML:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2edc3908f2f6d4358c40dd98a42e83909db0262d
+            qca:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5dbb9a0ca240f1587894242db957885668ee445c
+            qdox:
+                rationale: Part of the first base-runtime prototype.
+                ref: d0e485c3cab6667f6855f7b603a868921803e197
+            qemu:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8a588691e28f1a64e192f9408286df4cdd11a7b5
+            qemu-sanity-check:
+                rationale: Part of the first base-runtime prototype.
+                ref: e2b3eec5031585cbcf741e4f3e59e115b436e5e6
+            qhull:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9e1831a9753a4fe67f5dea27786f571b063ef4b4
+            qjson:
+                rationale: Part of the first base-runtime prototype.
+                ref: a11e5985d3e3fe21f6134e394b82af2b0b210c43
+            qpdf:
+                rationale: Part of the first base-runtime prototype.
+                ref: a3d0a69ad27af3dd045428bcf0230db164419aa7
+            qpid-proton-java:
+                rationale: Part of the first base-runtime prototype.
+                ref: bb0d77e2305f7f3fcdd6bb0c4bccd8107b0c0149
+            qrencode:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6a9766d81b9760713e2056d696646904c46b83fc
+            qrupdate:
+                rationale: Part of the first base-runtime prototype.
+                ref: eb541813b360ca984e3254aa8ebe2b17d66796b0
+            qscintilla:
+                rationale: Part of the first base-runtime prototype.
+                ref: 71293e2de88e3b523e54cb195c3759494d6f5c81
+            qt3:
+                rationale: Part of the first base-runtime prototype.
+                ref: 470ea4af7c5ce8e6d23949e719b87cf31dc3bc76
+            qt5:
+                rationale: Part of the first base-runtime prototype.
+                ref: bb3e5a436e1cb87ae19b7450568c4d66670de85f
+            qt5-qtbase:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8ddb897df61935384f1dbeee7111d981e553265f
+            qt5-qtconnectivity:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9eb511e1b6c8a3df380a18e7d520af0c3f7a4ebb
+            qt5-qtdeclarative:
+                rationale: Part of the first base-runtime prototype.
+                ref: 29b4c1b5004172fa52bb7f83ba1ec0786bf4e9eb
+            qt5-qtenginio:
+                rationale: Part of the first base-runtime prototype.
+                ref: 60414955a380e1af1f15656cd405d87f7052e4d5
+            qt5-qtlocation:
+                rationale: Part of the first base-runtime prototype.
+                ref: 78719043918cfe5b415cc8593c07ea29abab9fa0
+            qt5-qtmultimedia:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6464f02754d78fe6d8ecd2bcebf1e2d30a4c9356
+            qt5-qtquick1:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0070cbef11e81946aa6756f74cd31913fa8230d6
+            qt5-qtscript:
+                rationale: Part of the first base-runtime prototype.
+                ref: df826b0cd579d4095e860a6aa34559cc4e8345a6
+            qt5-qtsensors:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9df173774e5c99e9977596ea1e76104b3c44d316
+            qt5-qtserialport:
+                rationale: Part of the first base-runtime prototype.
+                ref: ff17b47a4ef50dac677e17cf5aa971b32860cd31
+            qt5-qtsvg:
+                rationale: Part of the first base-runtime prototype.
+                ref: cb42e91f5e0e6382cb00ac638f3f21952a0b584e
+            qt5-qttools:
+                rationale: Part of the first base-runtime prototype.
+                ref: a269532a0b62893d46c24894b8fedef286188a2f
+            qt5-qtwebchannel:
+                rationale: Part of the first base-runtime prototype.
+                ref: c52d7a635dd3b4ac73f44214ced3689eedd62d01
+            qt5-qtwebengine:
+                rationale: Part of the first base-runtime prototype.
+                ref: 28117fc6000ec134ec65447f2de733a43a4d8b1d
+            qt5-qtwebkit:
+                rationale: Part of the first base-runtime prototype.
+                ref: af3fdac354c6cad5b429b08865b86500c59a515d
+            qt5-qtwebsockets:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0984f259bd4da185f523f6507b11f6cf6850ef13
+            qt5-qtx11extras:
+                rationale: Part of the first base-runtime prototype.
+                ref: b18912f216816a0f15898f141c550cfa5d388781
+            qt5-qtxmlpatterns:
+                rationale: Part of the first base-runtime prototype.
+                ref: a53c1e0b120c6b884efcbef38d79608608b41e19
+            qt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8d832b1c1ed4d66281ae1ee2bf1b370b785c7bca
+            qt-assistant-adp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5d5b24123460a0b8bd1d093d6d0d19ea7f4c421a
+            qt-mobility:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4b7d6e7a7415cf401d5a6bb78c5dfb4bb08820c0
+            qtsoap:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2e096e8b60ddbab6f3fb6271b29c5ab76421e88e
+            qtwebkit:
+                rationale: Part of the first base-runtime prototype.
+                ref: a6ca6b93b776f7541cd992e17ea7cfccfbd254a3
+            quartz:
+                rationale: Part of the first base-runtime prototype.
+                ref: c75f99a2f07bb30a0aace5732563b46815f4a644
+            quota:
+                rationale: Part of the first base-runtime prototype.
+                ref: 80cb0d858b79abd4d7cd238c10bc0d171c19999d
+            rabbitmq-java-client:
+                rationale: Part of the first base-runtime prototype.
+                ref: b716577db82dc857bcd6e888e67781fa1a08d9e7
+            rabbitmq-server:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0a3d3904a72b1edae398726165efc5e7577b6111
+            radvd:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7ded213de59db0dfc681adb69c8fe1b9d37b8572
+            ragel:
+                rationale: Part of the first base-runtime prototype.
+                ref: b00fd19deb47b0a33a7c8e8eb8ff93876c3f350c
+            randomizedtesting:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9ea738212c59fa1b4e8156ab91e85b3d2938b0ab
+            raptor2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8534157d2ce9c22c4063950b14451850ee85cb7d
+            rarian:
+                rationale: Part of the first base-runtime prototype.
+                ref: fe9985bde05590ff59abb930f157019279e973ad
+            rasqal:
+                rationale: Part of the first base-runtime prototype.
+                ref: bc3d26bac524a84646e409df6385609fdbb1faf5
+            R:
+                rationale: Part of the first base-runtime prototype.
+                ref: b9225cea9167e6da16619f7834839a875539a745
+            re2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3734d081a401bce88484703314b3a65bc48a231a
+            re2c:
+                rationale: Part of the first base-runtime prototype.
+                ref: 70e19d19bd05c6b563e1ae3ccb91cb291d7536d8
+            readline:
+                rationale: Part of the first base-runtime prototype.
+                ref: 48ee2ac2462fd04c15f266bf64212b28e3d1f561
+            realmd:
+                rationale: Part of the first base-runtime prototype.
+                ref: c369c40836d2311d89309082f6cdee4be14e1561
+            recode:
+                rationale: Part of the first base-runtime prototype.
+                ref: a7cb467308ce0f32898dc4f66657080ae7601944
+            redhat-lsb:
+                rationale: Part of the first base-runtime prototype.
+                ref: fb170cb7333665c2bb6ba6f118565814487f9e83
+            redhat-menus:
+                rationale: Part of the first base-runtime prototype.
+                ref: efc69e347e9fa57769006e845ff535a5e2a844e7
+            redhat-rpm-config:
+                rationale: Part of the first base-runtime prototype.
+                ref: 210d060ccc651dd9be2feac1ff832d1f849ab098
+            redis:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5e29ea2ef7786181fff5c07d2bdfb01ea0a003c8
+            redland:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3a16c8a346737e42688f6723a4d7a25f363a41ef
+            reflectasm:
+                rationale: Part of the first base-runtime prototype.
+                ref: eee5b196bd18b5f568344ecf155ef0c27f272686
+            reflections:
+                rationale: Part of the first base-runtime prototype.
+                ref: 08c85c208849e062d21a92039ac93d308531912c
+            regexp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6cce9db696a75022fe836253a7641cdafaafee02
+            relaxngcc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3a9eeef8f1bbef6ee9759c6f17f183a470922773
+            relaxngDatatype:
+                rationale: Part of the first base-runtime prototype.
+                ref: fcefa66ff50ecdd6b582f18c9b0d35bd25837918
+            remotetea:
+                rationale: Part of the first base-runtime prototype.
+                ref: 40132c8c4d1f04e7ec481061a66a6774212c18f4
+            replacer:
+                rationale: Part of the first base-runtime prototype.
+                ref: f6cb1b7cf9bfdd190efed3e7bd729cb229516b3e
+            resource-agents:
+                rationale: Part of the first base-runtime prototype.
+                ref: ed7d39fd2a81a374c339009143af5e6407d83bbf
+            rest:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8d103e17f0a652df665bb99d858e5cfbb3856e3d
+            resteasy:
+                rationale: Part of the first base-runtime prototype.
+                ref: f39ab210561b19cf55dcb3d8fcde491661bf573e
+            rhino:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9d266e489d132529a6259410dbe19d7c1b5a3ba0
+            rhq-plugin-annotations:
+                rationale: Part of the first base-runtime prototype.
+                ref: c6ff422d51f3575ba2e27b20ba89139e03d8f069
+            rmic-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 56090830511dbbd0c996698d26a30d55ec54bba9
+            rome:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6ebf28a03b9f594b5c99605bec7d154386acabe4
+            rpcbind:
+                rationale: Part of the first base-runtime prototype.
+                ref: f2ad40f13668ecb6043f4c9f9603244c79055bcd
+            rpm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6a38aee710629f3d5650eb013a7616a60e0d5f6d
+            rpmdevtools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 85d8faeb9b0776d1b901e47e40021666506ce190
+            rpm-mpi-hooks:
+                rationale: Part of the first base-runtime prototype.
+                ref: b1f9621afe3daa22a638855965f5a81a51113c7a
+            rrdtool:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0db4edc7a144f536fe653d940a747e7d10f8f98f
+            rsh:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8a2d7c9993e129ad9fff75562ca592cdf952222b
+            rsync:
+                rationale: Part of the first base-runtime prototype.
+                ref: dd26cef88b4eb851f5dd49554f28c452e08e2bf8
+            rsyslog:
+                rationale: Part of the first base-runtime prototype.
+                ref: 230640f587e7a36e9a3f06e499eddddffa9e797a
+            ruby:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7684b6800d525e61d12253b21efa2447f4f5ad26
+            rubygem-actioncable:
+                rationale: Part of the first base-runtime prototype.
+                ref: eaaacad90de9846491eb67a4371c40ccd10b9c2f
+            rubygem-actionmailer:
+                rationale: Part of the first base-runtime prototype.
+                ref: af3ff7d2ac87daad63584084ef5cbb61791263fa
+            rubygem-actionpack:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94fb82f928dccb9c1129eafaf8eaa1a577b9f1be
+            rubygem-actionview:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7c3f6ebb36bbcc72c3f28e9791cdd1a40c32fcbb
+            rubygem-activejob:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0820e83a9d2f7fb9e653e63f37cdb1a08e95b1f1
+            rubygem-activemodel:
+                rationale: Part of the first base-runtime prototype.
+                ref: a6f6d58e7dcce2096d4ac29c3fbbcfeedc1e3146
+            rubygem-activerecord:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7ca433112fa98e6a8e458129c7b61e0e986b9566
+            rubygem-activesupport:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2e65ab3628153c39031585c010dfb623709ee729
+            rubygem-afm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0de274ce30d64c7b850f7dc4ed3c398aa6a6c664
+            rubygem-arel:
+                rationale: Part of the first base-runtime prototype.
+                ref: c9419d0b3d559dcb0fe1a7d4ac9dd45cba5bb319
+            rubygem-aruba:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5ae2b8c61342d3dd490df75a7db3bc7656d6aa0d
+            rubygem-Ascii85:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1e42b9eb7ba1580b92dffa4176ab247596ec6f14
+            rubygem-asciidoctor:
+                rationale: Part of the first base-runtime prototype.
+                ref: 90ffac924394ffe06ce79ffd95b23ba46ef09455
+            rubygem-atomic:
+                rationale: Part of the first base-runtime prototype.
+                ref: f00438289e1c709851bb05f456377368f971cb09
+            rubygem-bacon:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7368149b1c0ced0b7b03764d85382ceca03d47ae
+            rubygem-bcrypt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5d769697ee377ee2063e31b661bfc6d16f169e89
+            rubygem-builder:
+                rationale: Part of the first base-runtime prototype.
+                ref: b459c533c2f64c975389717cf62d2551284bdfe1
+            rubygem-bundler:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3930ce0860519e9462d3879b98aea241218e9e09
+            rubygem-capybara:
+                rationale: Part of the first base-runtime prototype.
+                ref: 815cae03b9a2246302608773e04aaa80b647df62
+            rubygem-childprocess:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1650c2114d462620148c936314c18345e22bd892
+            rubygem-coderay:
+                rationale: Part of the first base-runtime prototype.
+                ref: e50f571dda616c953ff481bbd0d94c62501bea04
+            rubygem-coffee-script:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4262372f8c4eef8ca19ab4eeea973d925c64b236
+            rubygem-coffee-script-source:
+                rationale: Part of the first base-runtime prototype.
+                ref: 48775ba1ef34ae5663858932c71c7d3f458c3502
+            rubygem-concurrent-ruby:
+                rationale: Part of the first base-runtime prototype.
+                ref: 60be4c211103636391b47014e583a69b8e8dfd69
+            rubygem-creole:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6794cf98e7a9375b9b3e27a65a2cb288bc5baba1
+            rubygem-cucumber:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3d962e17d4f9fe8b536fb2840bf28f0b0d372a1b
+            rubygem-cucumber-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: 632898e7381e0362b300e5386f4124746df3b85e
+            rubygem-cucumber-wire:
+                rationale: Part of the first base-runtime prototype.
+                ref: 37a88ca831dd3c5de5f3ba6ccc7f1c2e2dd9ea5d
+            rubygem-daemons:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6615c957e70cc8d0f6437164c67a47d5ec0e47e8
+            rubygem-dalli:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5f0f9743fb45647db35abda0c0f58efaf40b801f
+            rubygem-diff-lcs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 584ba335e81da00365ed634a9605c85a35a9490a
+            rubygem-docile:
+                rationale: Part of the first base-runtime prototype.
+                ref: 398fd2b4bc7906ae4ade4e34dd1b9947adc63a9d
+            rubygem-ejs:
+                rationale: Part of the first base-runtime prototype.
+                ref: a5fc0fe9c0b1973572bc252ff0e805ca4c17e3d3
+            rubygem-erubis:
+                rationale: Part of the first base-runtime prototype.
+                ref: e5456b51dcfa736b3d6faac0dc283eaf571b92ee
+            rubygem-eventmachine:
+                rationale: Part of the first base-runtime prototype.
+                ref: 118427e5e1b85c3a2a4b0414e5287570c37772b5
+            rubygem-execjs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3c0f1ff0c98c30d501659beea540aa206f2c3d66
+            rubygem-expression_parser:
+                rationale: Part of the first base-runtime prototype.
+                ref: cb5510030a3e306d6fcec1742a5ae15e5502bced
+            rubygem-fakeweb:
+                rationale: Part of the first base-runtime prototype.
+                ref: fd539bef69ace8bfb3c015c9712253244b35ec55
+            rubygem-fattr:
+                rationale: Part of the first base-runtime prototype.
+                ref: 278b1b1676faea5924b1d90d7db7b86bdbe0037e
+            rubygem-ffi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4bd9250d41debc4231cd7b593e6c8bb3cce9fa4c
+            rubygem-flexmock:
+                rationale: Part of the first base-runtime prototype.
+                ref: b75937691dbc56fee2c6a14870d0f2f33aada33e
+            rubygem-gherkin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5c70b3dceb023137d61f91fb983908975b18d24b
+            rubygem-globalid:
+                rationale: Part of the first base-runtime prototype.
+                ref: 29ea6834a3867039e7584040b81b46a65c2d81a1
+            rubygem-haml:
+                rationale: Part of the first base-runtime prototype.
+                ref: 51b29d53e2afca67011bb76905a32f0564177b83
+            rubygem-hashery:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3d4a54ebadddced4fc97d081ae3c1b79211270d5
+            rubygem-hoe:
+                rationale: Part of the first base-runtime prototype.
+                ref: 63db9ad50ff76193254b0bf4bd5d92ddb95226bc
+            rubygem-hpricot:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3254b8e5ee56a5ee0d507a0417130b9e90e0c56c
+            rubygem-http_connection:
+                rationale: Part of the first base-runtime prototype.
+                ref: 456c360bbc13395ea286df8e05255444524a05c0
+            rubygem-i18n:
+                rationale: Part of the first base-runtime prototype.
+                ref: e16aec19405cf34fab4aae70a4d82072a8e8815f
+            rubygem-introspection:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9557c42d821531f2e9e807973422ebd84d28ead2
+            rubygem-jquery-rails:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6546e049bee1f3674d3a038944b297c1a8be0462
+            rubygem-json:
+                rationale: Part of the first base-runtime prototype.
+                ref: 653691e2ec2827705b55625646a4d30740620ac9
+            rubygem-json_pure:
+                rationale: Part of the first base-runtime prototype.
+                ref: ebc930b832217bf66b4fe5649cfdf7cd02ca0af4
+            rubygem-kramdown:
+                rationale: Part of the first base-runtime prototype.
+                ref: ac6210795b4cf9f7323670b08a756d93059c8327
+            rubygem-liquid:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2c0b8721c1b21468c215841ac2ab5575d7ad681d
+            rubygem-loofah:
+                rationale: Part of the first base-runtime prototype.
+                ref: d05510b42291f08fe2ed2d41fe1b0f3fdc2cf172
+            rubygem-mail:
+                rationale: Part of the first base-runtime prototype.
+                ref: ab0842ee9c01359ceebf2a5ddcba5abfad6cbd98
+            rubygem-maruku:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4835a898e25229daf24cb5cd56a98ab1f3180e68
+            rubygem-memcache-client:
+                rationale: Part of the first base-runtime prototype.
+                ref: 187f9ad22ffc3919080474d7eeae7f18bd46e14e
+            rubygem-metaclass:
+                rationale: Part of the first base-runtime prototype.
+                ref: 97972eb557276a6287a4c44ae3ce81443ac97683
+            rubygem-method_source:
+                rationale: Part of the first base-runtime prototype.
+                ref: f28a4d8e9505568bb5cce9c099f12b8ad834360e
+            rubygem-mime-types:
+                rationale: Part of the first base-runtime prototype.
+                ref: 040078442dbe4017e27b40384a07219140bd7438
+            rubygem-mime-types-data:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1fd6b684ed40254005a91854ee194e2f92c3e6a5
+            rubygem-minitest:
+                rationale: Part of the first base-runtime prototype.
+                ref: 48f556632826276a48db7e0fdaa9b2554e11d5c0
+            rubygem-minitest4:
+                rationale: Part of the first base-runtime prototype.
+                ref: a1d175364fa1b7bd725c3df40970037bd718d8bd
+            rubygem-mocha:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0968a8cf7ae36ceeea48579a820c6dbbb6387218
+            rubygem-multi_json:
+                rationale: Part of the first base-runtime prototype.
+                ref: ed9912b1ee0b75882587c75803c19368ef9f4beb
+            rubygem-multi_test:
+                rationale: Part of the first base-runtime prototype.
+                ref: b2dd037f1e8ed9bc0f4e5ea870ac67eed20b050d
+            rubygem-mustache:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8417687d8535988dc201a3dd39c9f217cc5c11f1
+            rubygem-nio4r:
+                rationale: Part of the first base-runtime prototype.
+                ref: 101f50e26dd76c12ae8115254181398a9cebb3a5
+            rubygem-nokogiri:
+                rationale: Part of the first base-runtime prototype.
+                ref: d1e7caeedbb980612f246def598b102206664828
+            rubygem-org-ruby:
+                rationale: Part of the first base-runtime prototype.
+                ref: 46cd92089204e6820409c9e9f95a9ba8e851a33a
+            rubygem-pdf-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: ea92d91ce0c92de6968e6c2ad6d83bc716ea1bb1
+            rubygem-pdf-inspector:
+                rationale: Part of the first base-runtime prototype.
+                ref: f9dcac9c5aa5887cd650e7882119f21977d1b5e6
+            rubygem-pdf-reader:
+                rationale: Part of the first base-runtime prototype.
+                ref: a33ac6995eb5df08a05c7e7179b03f6b0cec689a
+            rubygem-pkg-config:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4039e09fd01a1a808f649446bcf53329265447bd
+            rubygem-power_assert:
+                rationale: Part of the first base-runtime prototype.
+                ref: 74015728d50b27015bfc0015a6a3f4d317e66fbb
+            rubygem-prawn:
+                rationale: Part of the first base-runtime prototype.
+                ref: cd860d36370b8204755454ba2946a6ec63f46821
+            rubygem-rack:
+                rationale: Part of the first base-runtime prototype.
+                ref: 20395173620e605f8ccdb55d388ac68edf15fe24
+            rubygem-rack-cache:
+                rationale: Part of the first base-runtime prototype.
+                ref: e655c2d4a78297da23f95cb1b16733a4aa6fa490
+            rubygem-rack-protection:
+                rationale: Part of the first base-runtime prototype.
+                ref: b9004780b875622d2914f126372c694a19824795
+            rubygem-rack-test:
+                rationale: Part of the first base-runtime prototype.
+                ref: e308e35ddd269ecd3171b9c54b32bb587480293a
+            rubygem-rails:
+                rationale: Part of the first base-runtime prototype.
+                ref: cfa649b56f5c6a4e26616c0af8ed5d8051a8bdb9
+            rubygem-rails-dom-testing:
+                rationale: Part of the first base-runtime prototype.
+                ref: a53c20fc96b0888f71573c40a8da8ce5d533d2ae
+            rubygem-rails-html-sanitizer:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7a670c20ae05ab06a1541459d1bd7d3df7163ef0
+            rubygem-railties:
+                rationale: Part of the first base-runtime prototype.
+                ref: 69f69ecd3c0d1095f30575e24020f229cccef77a
+            rubygem-rake:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1d2249a8ef514b2c05c242dcb0a75ed2e80e68e7
+            rubygem-rake-compiler:
+                rationale: Part of the first base-runtime prototype.
+                ref: 60bb9e0d1cacd6eb2449ce236390999e39ea98c4
+            rubygem-rdiscount:
+                rationale: Part of the first base-runtime prototype.
+                ref: cda5b6ac92bade41c59883dab1dccadee04c028b
+            rubygem-rdoc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94ae4c49f1775fa30b28a35e48dc43aca2518843
+            rubygem-redcarpet:
+                rationale: Part of the first base-runtime prototype.
+                ref: c35001293e41241ad28d11a7a6c120749f47360c
+            rubygem-RedCloth:
+                rationale: Part of the first base-runtime prototype.
+                ref: 634f62480295d874f906580e95efb3853d340204
+            rubygem-redis:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3e4ad70ee926074b21c4a001d54f29d7aa8a4fb3
+            rubygem-ronn:
+                rationale: Part of the first base-runtime prototype.
+                ref: 640f611340a4cb4ad6b48d95e05871932e07c158
+            rubygem-rr:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2eed7fcce66ab8833a4375124c51e4d320a5c0df
+            rubygem-rspec2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 22a20b1f054f2c5f129807bdd92b6082c3be9409
+            rubygem-rspec2-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: cd45f86f5ce3c169996892c01fa577268036e774
+            rubygem-rspec2-expectations:
+                rationale: Part of the first base-runtime prototype.
+                ref: 34c431ed65e6165d57c8e806089ad793aa9d02f6
+            rubygem-rspec2-mocks:
+                rationale: Part of the first base-runtime prototype.
+                ref: ac093aa5723c362bb3129cfdfca5830844b7f7bd
+            rubygem-rspec-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: 98927e4576cee850dd3caacd8f606cb74e9d1cff
+            rubygem-rspec:
+                rationale: Part of the first base-runtime prototype.
+                ref: e8fa1b4775fe9e1826b680339d81a960a344bd2d
+            rubygem-rspec-expectations:
+                rationale: Part of the first base-runtime prototype.
+                ref: db74cf1175038dcb703d21186ded0100aa7282db
+            rubygem-rspec-mocks:
+                rationale: Part of the first base-runtime prototype.
+                ref: 26b4a3f5db1805aa45599d98c2b9fc70b2bfe6e7
+            rubygem-rspec-support:
+                rationale: Part of the first base-runtime prototype.
+                ref: 42b63df6cf7472dcdb5cff1fd4f2b5ce9322885a
+            rubygem-rubypants:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9d5267a029aaf670a560c3e4e6f3a72f0a4fcafe
+            rubygem-ruby-rc4:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8d09d125611d752b1fb5eda96cc801c1a559b1b4
+            rubygem-sass:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8b4be5b5db87c1615575c81e25b21abdfca40bf7
+            rubygem-session:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7e46f648f46f0bd79f345edcbabb82d6c35ce5ae
+            rubygem-simplecov:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0c4bd1dfb9f032c8b8824bcad1c4cf3d21a661a2
+            rubygem-simplecov-html:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0160e4917a03a0f6f8fc1a81129b69862caf3148
+            rubygem-sinatra:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8302300729818d5217ddace36614eadc680aef17
+            rubygem-slim:
+                rationale: Part of the first base-runtime prototype.
+                ref: fd7ad613165fbab298281c0452dea4b5e494e0fe
+            rubygem-sprockets:
+                rationale: Part of the first base-runtime prototype.
+                ref: 142797a41b16a6dae9be7d7e8efbad4de35fd59f
+            rubygem-sprockets-rails:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9a11450fd4e33faff6c8c64fa1890b0812accff7
+            rubygem-sqlite3:
+                rationale: Part of the first base-runtime prototype.
+                ref: 786cb222d1d9a9f44604edebfa60aeca54a089f2
+            rubygem-temple:
+                rationale: Part of the first base-runtime prototype.
+                ref: cb2f08f6b226ea2243f4b17f4aed2d2413d205c4
+            rubygem-test_declarative:
+                rationale: Part of the first base-runtime prototype.
+                ref: 850ca275a2ca10c474e9fcf25a9d1307317ce8a7
+            rubygem-test-unit:
+                rationale: Part of the first base-runtime prototype.
+                ref: b74ca42f6a279b278903bd2699073c3b6c39b801
+            rubygem-thin:
+                rationale: Part of the first base-runtime prototype.
+                ref: d19af9234ce5527e96fa5d0808034b6205a22877
+            rubygem-thor:
+                rationale: Part of the first base-runtime prototype.
+                ref: d1d64bbabccd9fcaab0c7db57e1b8c4acc960cea
+            rubygem-thread_order:
+                rationale: Part of the first base-runtime prototype.
+                ref: 28fa4f5c3ad6220676adef035ce5b56992b5e656
+            rubygem-thread_safe:
+                rationale: Part of the first base-runtime prototype.
+                ref: bdd6ce76eca26edcc395c2fa63fbe7b3c8acf604
+            rubygem-tilt:
+                rationale: Part of the first base-runtime prototype.
+                ref: 43552c0fc042a4597867a22e61125de9eb849a51
+            rubygem-timecop:
+                rationale: Part of the first base-runtime prototype.
+                ref: 499f7ae1acfce769a5c4c35fa3c763ea745b179d
+            rubygem-ttfunk:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2038a8b057c86bafc2319fd37d1f6e26f733aadc
+            rubygem-turbolinks:
+                rationale: Part of the first base-runtime prototype.
+                ref: f51c31b65a0d0ba5341322fc8d8ec43a98d5daac
+            rubygem-turbolinks-source:
+                rationale: Part of the first base-runtime prototype.
+                ref: cca33deb3c0b8f20f6e92a544cde1f530342f9ad
+            rubygem-tzinfo:
+                rationale: Part of the first base-runtime prototype.
+                ref: 12cf029f1bd45b4399b6a0a6c4f273bdd0c6bfe2
+            rubygem-uglifier:
+                rationale: Part of the first base-runtime prototype.
+                ref: 95852f3f7a09f010375fdb951df7ae4e508e6710
+            rubygem-websocket-driver:
+                rationale: Part of the first base-runtime prototype.
+                ref: c82ae5a694daff9f425709068a5ee0b4537dfb08
+            rubygem-websocket-extensions:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3eac6669dffcbd110062c395725a83856b0c3336
+            rubygem-wikicloth:
+                rationale: Part of the first base-runtime prototype.
+                ref: 86db635cec1c8c86888a390d3e7cccf40b14e202
+            rubygem-xpath:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1b125ab269610f173e339cae65572bba46da76ca
+            rubygem-yard:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2d72402ab3bfa6e3ea4db72209852df22a58371d
+            rubygem-ZenTest:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1c27297610c0e285e62f484575bc2d8030c4fd20
+            rubypick:
+                rationale: Part of the first base-runtime prototype.
+                ref: bdb864648a1423c3070c922c2f6476d002acdebd
+            rxjava:
+                rationale: Part of the first base-runtime prototype.
+                ref: e0fa8957d6d5a16861bef68bf280bc9c87a40f67
+            sac:
+                rationale: Part of the first base-runtime prototype.
+                ref: c1569fd395813d0763f020dd361f107e0e7020e3
+            samba:
+                rationale: Part of the first base-runtime prototype.
+                ref: 747b64a3ad479b3e059747a48735a00b931ba37d
+            sanlock:
+                rationale: Part of the first base-runtime prototype.
+                ref: 36b0cc4a9f48081a7b15309cbd96d8759ad97291
+            sat4j:
+                rationale: Part of the first base-runtime prototype.
+                ref: b4f30c7a75d6a11210fe2f0e619a9add35214dd7
+            satyr:
+                rationale: Part of the first base-runtime prototype.
+                ref: e044083467e6ae7b67c7875ed11d85b0b46d34fb
+            saxon:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9004fdaaf1fb961c30322c086bde3ce5a651b61c
+            saxpath:
+                rationale: Part of the first base-runtime prototype.
+                ref: 457bccb7caebc10d247f7919d149b463c15d49a2
+            sbc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 72ebbb04912b51d4a7e80b6b3231c20d768955d0
+            sbinary:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6584f99f83ac609c4658761da847a4948efb07fe
+            sblim-sfcc:
+                rationale: Part of the first base-runtime prototype.
+                ref: d6723e7d6f704fcb34de3b42401e1d56f9570b1f
+            sbt:
+                rationale: Part of the first base-runtime prototype.
+                ref: dab9773717e6cd394d8f6ffd9be716b9e8dc1056
+            scala:
+                rationale: Part of the first base-runtime prototype.
+                ref: 65c65ce3cd941cc7df5557f1b92b83b49c4e9eeb
+            schroedinger:
+                rationale: Part of the first base-runtime prototype.
+                ref: c0f8c15750b120d134dfec364af20b65ca96ddf9
+            scl-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1b7dd2dce6c9942ce8037b5a02ea27252a60d3d2
+            scons:
+                rationale: Part of the first base-runtime prototype.
+                ref: 59a5ff54a967a58acaee2678b6bc682361c692fe
+            screen:
+                rationale: Part of the first base-runtime prototype.
+                ref: d141e2e66048e53a0a54d1a6af393cf8e098fe59
+            scrub:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5fe40a2a772ee6773537cd457ebcfbe0d03dd981
+            SDL:
+                rationale: Part of the first base-runtime prototype.
+                ref: 04a3a7b1bd88c2d5502292fad27e0e02d084698d
+            SDL2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0bfd38e6dc9239e8bd1160fe8246a022622a8de8
+            SDL2_mixer:
+                rationale: Part of the first base-runtime prototype.
+                ref: f38b76b4c9ca58f80b8a816e519174f58426464b
+            seabios:
+                rationale: Part of the first base-runtime prototype.
+                ref: c31d40059be0a35eb937e38d67e929d9779771b9
+            sed:
+                rationale: Part of the first base-runtime prototype.
+                ref: a157645f7ac6751f0b7ae54dccb2b2e2adbfd646
+            selinux-policy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3b2028809f90b6739f01557048decce9bf3869ee
+            sendmail:
+                rationale: Part of the first base-runtime prototype.
+                ref: df0a3227a9c207dfa93e1f6f75e65b8d299d3bed
+            serp:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1896cc013d77bfd6e6f0177bc03d6128d1d1cbac
+            setools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1299b6abea0d88387b36229f55963684ac80d4bb
+            setup:
+                rationale: Part of the first base-runtime prototype.
+                ref: b154c0f8b4fffc423bb2d5a6fd7eac3f4caff766
+            SFML:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6c55f54f893fd5cf3249ddefcf3a5861b0eb4270
+            sgml-common:
+                rationale: Part of the first base-runtime prototype.
+                ref: ee0d25ab2bb5ee3fd81bb162c2445389aeba4c33
+            sgpio:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6360077161033f10b3eec603ddcc3f1e71f549da
+            shadow-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: c50e17082d12c2ee8735024567cbbf0ad07acb1f
+            shared-mime-info:
+                rationale: Part of the first base-runtime prototype.
+                ref: 78879d7ea7308ee934ebdf9380ae575863b2aa4c
+            sharutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6b8e281be95fcefff2891178bab7065b0acc3da4
+            sheepdog:
+                rationale: Part of the first base-runtime prototype.
+                ref: f25932db853b0cb37b6182b5c95d1b7e0ae835b0
+            shrinkwrap:
+                rationale: Part of the first base-runtime prototype.
+                ref: befa5bde1a43ab97cfdfd28e3e0dc9c2d08aad41
+            shrinkwrap-descriptors:
+                rationale: Part of the first base-runtime prototype.
+                ref: 07bf91979bcec1b4df46def603dcae33df018e4b
+            shrinkwrap-resolver:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8200f5adaa4cb4d227526f21d28f051adca67278
+            shtool:
+                rationale: Part of the first base-runtime prototype.
+                ref: 81dce983830cb8cce0c9595cbfcafff57ed8e06d
+            simple:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9b87be658c575573a5d4e5dc048b4a069863c5a6
+            simple-jndi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7cebf5cb4339c29cb8e4b5be468f338343d7c4c8
+            simple-xml:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3c4bc392dcf3e928275547bf05151a2be02a9057
+            sip:
+                rationale: Part of the first base-runtime prototype.
+                ref: d5187d9cd1f5243e851364551c92143ffb4a3120
+            sisu:
+                rationale: Part of the first base-runtime prototype.
+                ref: 298008414ee05913abd4a484ffec9c2d9ec8f95d
+            sisu-mojos:
+                rationale: Part of the first base-runtime prototype.
+                ref: 433917c92c27368dcf6cb8e8fbb1d5fbfdbae774
+            slang:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8ffa876f197e80ced5951cb984aa97d6c6cc1b9d
+            slf4j:
+                rationale: Part of the first base-runtime prototype.
+                ref: a0aa8fd1bf2ceb2b241629694c59d8dfa69518de
+            slf4j-jboss-logmanager:
+                rationale: Part of the first base-runtime prototype.
+                ref: ebf6ccbc0b705a916b3a100804f61983dab99a52
+            slv2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9fc717c08a275e31273a3ce82b7da7142a07fd57
+            snakeyaml:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8992ce6e0e99350c15287368562e530f4c779214
+            snappy:
+                rationale: Part of the first base-runtime prototype.
+                ref: d13ab965afff140e5c2567df74e449a8aa1c2bc2
+            snappy-java:
+                rationale: Part of the first base-runtime prototype.
+                ref: da45ad99071abce670334e042ed4445d81e3a563
+            snowball-java:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5701097f5bac2634bbe5b44ae3cb2305d5c5d2ee
+            socket_wrapper:
+                rationale: Part of the first base-runtime prototype.
+                ref: ca489e45287c38ddfc1c5d84b6103bbadcb53ded
+            softhsm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 82f91fe54577003f7dcecfbc14f0d454b0203751
+            sombok:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94e6783c9b7f24947d2811fe90d16aee40e0d747
+            sonar:
+                rationale: Part of the first base-runtime prototype.
+                ref: d98d3688da0a0757cd11800a2b0f3bc0aca34d36
+            sonar-update-center:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9469d15c4fd682f5f5b2523e840f5f60ab29e732
+            sonatype-oss-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0f78b5e5af59d6f308edeba27004be0a300659c7
+            sonatype-plugins-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94ee5be413a69c5e37f58c1813258ae1bbc54906
+            sound-theme-freedesktop:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7cedff963774db8e9efe9caa9e3ea36e2caeeae6
+            soundtouch:
+                rationale: Part of the first base-runtime prototype.
+                ref: c9ef9a5420dba4f8a60ec262604263131a161bc6
+            source-highlight:
+                rationale: Part of the first base-runtime prototype.
+                ref: 375262d21370f0fb5442666f0bd60c45edab9752
+            soxr:
+                rationale: Part of the first base-runtime prototype.
+                ref: 20649b1ebf66e514a87fd49e4d8e98c5ecf24ded
+            spatial4j:
+                rationale: Part of the first base-runtime prototype.
+                ref: cbf759a9b49b40b3639e786d934fb904419032db
+            spec-version-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5d37ce7596aa3114c2c6c46291c92ee53ca4c3e9
+            speech-dispatcher:
+                rationale: Part of the first base-runtime prototype.
+                ref: e01832f512d76a152f3d24ed64bd1bca54798619
+            speexdsp:
+                rationale: Part of the first base-runtime prototype.
+                ref: bbedc1f6b2a43569d4a13c0e3a851d33e538b3aa
+            speex:
+                rationale: Part of the first base-runtime prototype.
+                ref: e494d742ed94f31ab84df12ba2f821d00ddbb076
+            spice:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7e0294db58589b1ee133a35ba20b2f0cf404df6d
+            spice-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3b998d5c90b06b9bd53490bad6add009f26b7023
+            spice-protocol:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4d37a3f07850ee5e9fb1733d631801088877cfe1
+            springframework:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8bbce322e45cccfb202b9e396924f5fc6edb6197
+            spymemcached:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7720aec9ec7b481604f47b91cd64022d95b59832
+            sqlite2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 17177a09609946d544a08155f540d64e77bf7fe7
+            sqlite:
+                rationale: Part of the first base-runtime prototype.
+                ref: 989e347e7f9678044544694dc06c9813e3c01fee
+            sqlite-jdbc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8c864430d453205e4f9a970c000ff8e033f7dfda
+            sshj:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8f295082939f47d4c135cc733926aede74515c78
+            sslext:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3beb0c1b1fac32ca7a007e41f606d06d5ee25b97
+            sssd:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7a5408348e034f69bdb0ea95529e1a46d2bbf6b6
+            star:
+                rationale: Part of the first base-runtime prototype.
+                ref: 03b7b29cf3aa6ec363be3bae00792ac2819adae1
+            stax2-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: d9ed6455d135e0dcc6aedbbaa49d0284b5523e01
+            stax-ex:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2d186e4da04e758f21ae8ec46be3693ef158bf8c
+            staxmapper:
+                rationale: Part of the first base-runtime prototype.
+                ref: ec121b8042d3cfcecc2a446e6016df538dfe3306
+            staxmate:
+                rationale: Part of the first base-runtime prototype.
+                ref: f614683cd0625437c4b1d76fb526b4fc5d340fde
+            storaged:
+                rationale: Part of the first base-runtime prototype.
+                ref: db13d596c68d64767928c0a069b27839f60485a8
+            strace:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3cc46cd063a0f5066816bc19b92d8ebfc1ffde48
+            stream-lib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5f45bf7695179312fb867270cb4116a2bc6d9e1f
+            stringtemplate:
+                rationale: Part of the first base-runtime prototype.
+                ref: 33bcd7b5fe4b6c1ed78a477bf924fa0d3c886cb8
+            stringtemplate4:
+                rationale: Part of the first base-runtime prototype.
+                ref: 62f5222a5c3a0dd7aef2ef96f776f27cb78997f4
+            struts:
+                rationale: Part of the first base-runtime prototype.
+                ref: b87aa7b6738e72bed685560b726f7c3874ae553f
+            stunnel:
+                rationale: Part of the first base-runtime prototype.
+                ref: e094c01be83cd2a95b076296efaa6c7266b35713
+            subunit:
+                rationale: Part of the first base-runtime prototype.
+                ref: f8c8f754630550d0b9eaa25c45ce8e6099789707
+            subversion:
+                rationale: Part of the first base-runtime prototype.
+                ref: a2b9f7990d8eb6a45704e691ada293cfcde5c42b
+            suitesparse:
+                rationale: Part of the first base-runtime prototype.
+                ref: d74eea8dafa6636fa7772b5c41ef3e7d86a72f1d
+            SuperLU:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1e65d3ab06fd478694474468e3397a4ea2a7cb3a
+            swig:
+                rationale: Part of the first base-runtime prototype.
+                ref: a785404834dbe610c2f1f80152088efdee9965f1
+            swt-chart:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4400b5d7de9d64c49ee7507602b3354a2451d79e
+            symlinks:
+                rationale: Part of the first base-runtime prototype.
+                ref: d8a04072dfc66f30fc09bb9fc415fc6eea8740e1
+            sysfsutils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 662cb560d2b0b7a42778bbca2289f2bb381caa6c
+            syslinux:
+                rationale: Part of the first base-runtime prototype.
+                ref: 78f96dd5d9650e009135c1c21c112658d7b146e3
+            systemd:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7ae71c8772a23ecfc58bc7e49ffcb3e5c78028a7
+            systemtap:
+                rationale: Part of the first base-runtime prototype.
+                ref: c39b8391fe6fe80f19fb1013cf10d507e4c5a234
+            t1lib:
+                rationale: Part of the first base-runtime prototype.
+                ref: b7c9eb650756fa0e23c93a3d6a27d36171bc272f
+            t1utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5f9db288c7bd3eafbddc3fe929c1d6ff29811626
+            taglib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8239ff0942260049340f391b053dedd93e49eec1
+            tagsoup:
+                rationale: Part of the first base-runtime prototype.
+                ref: 51cc213d455c91f5497dc2b4d3a3e44669891283
+            tar:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4841168324fc9c0b8bc4f0711e1c05faaca8b4ae
+            tbb:
+                rationale: Part of the first base-runtime prototype.
+                ref: 487f57941428c310003d531c3bad6ed22075824a
+            tcl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0024b402c2bcd98fe5408a288d33c5a8f4d9a686
+            tclx:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4afadbe00d65cedc091973dbe87a71a26f54c5bd
+            tcp_wrappers:
+                rationale: Part of the first base-runtime prototype.
+                ref: 00aefcec1b11c0e6f4286e3ca11423c903ebdbea
+            tcsh:
+                rationale: Part of the first base-runtime prototype.
+                ref: c58fda20b94e48341e1924a96da07d7142388d93
+            teckit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9812092804b02d4bde4fa9c846e4f5b94c85f788
+            telnet:
+                rationale: Part of the first base-runtime prototype.
+                ref: f13a0beb3bcc8e8417c5f0b5103610ecf99a1e4a
+            tesla-polyglot:
+                rationale: Part of the first base-runtime prototype.
+                ref: 273f0c0ef821a228889e1518b70be9cc46fead5f
+            tesseract:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6bc6e1f4c805faddccb372e8ea9028341c50ef62
+            test-interface:
+                rationale: Part of the first base-runtime prototype.
+                ref: b715ea86398c453b4e33a73e9b0da477834c0c39
+            testng:
+                rationale: Part of the first base-runtime prototype.
+                ref: 07151c9e89ab6ffcf1d204c4b8e3f88e766655f5
+            texi2html:
+                rationale: Part of the first base-runtime prototype.
+                ref: e4014ee6530eccc70019f99aee31accab8592a03
+            texinfo:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6c3a995c525511bac1716d0b5733dadc694f848b
+            texlive:
+                rationale: Part of the first base-runtime prototype.
+                ref: 932cadf3869f9454ac5fcc090333809c276ecbda
+            thredds:
+                rationale: Part of the first base-runtime prototype.
+                ref: b3ccb3be9e0fad419486a73ffe15b042b31f7b73
+            tidy:
+                rationale: Part of the first base-runtime prototype.
+                ref: 414b66cfd0e081a641262bd1bb208e3c2bbb356e
+            tiger-types:
+                rationale: Part of the first base-runtime prototype.
+                ref: 95ebbb2a33dc068d0f7715739790be110fa139c8
+            tika:
+                rationale: Part of the first base-runtime prototype.
+                ref: 74103fd6f628997dd0b549f4b037ac14c72ef461
+            tiles:
+                rationale: Part of the first base-runtime prototype.
+                ref: f6218ae0db2d385ca423022bfbdf1f0be71e3633
+            time:
+                rationale: Part of the first base-runtime prototype.
+                ref: 17449033fef70ecb78b1805755172779e564ff7b
+            tix:
+                rationale: Part of the first base-runtime prototype.
+                ref: a39c2da7bc5a0951f80a18158daeb9b824e083be
+            tk:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5a7b618c08e7b0301cac4726b10c013b0193383c
+            tokyocabinet:
+                rationale: Part of the first base-runtime prototype.
+                ref: a654cee088ba0ced071e2dd1d7032175ca741b91
+            tomcat:
+                rationale: Part of the first base-runtime prototype.
+                ref: 25834e621d26f6246080e4a20cf44580d85ddb4a
+            tomcat-taglibs-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: 127953093932740ec173b8606938b6bac399f45c
+            tomcat-taglibs-standard:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4185e831558e883c4326f2ffb55f993ddda0e9d1
+            torque:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2e637ee8e436b7e5191364fffc8bfe30c40b6b99
+            transfig:
+                rationale: Part of the first base-runtime prototype.
+                ref: 42a5c236783f372abdb66255af0793f383fa0234
+            tree:
+                rationale: Part of the first base-runtime prototype.
+                ref: 060509eb5ace8e61d87066345300f8380520eac6
+            treelayout:
+                rationale: Part of the first base-runtime prototype.
+                ref: d07322512d58e250b066d17757ec63666311a81a
+            tre:
+                rationale: Part of the first base-runtime prototype.
+                ref: f382d462b8cb28a52fc7b5b269b3d894e5858eea
+            trilead-ssh2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 961bd01cf79462a4169bcb65fcce96320afdf131
+            trousers:
+                rationale: Part of the first base-runtime prototype.
+                ref: f3171af1a6d9c665ee571090edc07de939fb53cd
+            truth:
+                rationale: Part of the first base-runtime prototype.
+                ref: 894f11d2bf551f83092af93092db7174716fc08b
+            tslib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0ac81c500826a67876dd5244d9d1968f5dfbd016
+            ttembed:
+                rationale: Part of the first base-runtime prototype.
+                ref: b3f37cd190f9dfeef901bf855df9efcd82c1ece0
+            ttmkfdir:
+                rationale: Part of the first base-runtime prototype.
+                ref: 869469801d53c654891493af339403064de5f3da
+            tuscany-sdo-java:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7540286e4332969c102df9d55cc615c6a2049633
+            tycho:
+                rationale: Part of the first base-runtime prototype.
+                ref: d6a767b61da8edc909c00e17155ba582d406151f
+            tycho-extras:
+                rationale: Part of the first base-runtime prototype.
+                ref: 05d9d570ee881ff6a4b4f3701b9fb77bedb621c7
+            typesafe-config:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1f0808950a7a4aea2ba36c369558f59c657042cd
+            tzdata:
+                rationale: Part of the first base-runtime prototype.
+                ref: a7aa7f1eb15ee39915c6e613c8f588e9f543e49a
+            uglify-js1:
+                rationale: Part of the first base-runtime prototype.
+                ref: 842c23a4e0f50d27e69f82bfa9f569d884b7c0fc
+            uglify-js:
+                rationale: Part of the first base-runtime prototype.
+                ref: 51cd0a0ef96eb2cf248a2b5b7aaf8bf8842d2a5f
+            uhttpmock:
+                rationale: Part of the first base-runtime prototype.
+                ref: 76d5f659e7f4740e3b63ca32ee774903be07e507
+            uid_wrapper:
+                rationale: Part of the first base-runtime prototype.
+                ref: 586b66ef77a3e111cd6776ce93074b7df1bfe511
+            uima-addons:
+                rationale: Part of the first base-runtime prototype.
+                ref: 30b8a4f95c61733a0ecf98102bc4498d26962834
+            uimaj:
+                rationale: Part of the first base-runtime prototype.
+                ref: 53b0a24f3317fb45d4f6b55df69eef9d81c5d7cd
+            uima-parent-pom:
+                rationale: Part of the first base-runtime prototype.
+                ref: 56a82e9a28192fbd502c3513b74c0ccd3155e064
+            unbound:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9c5452fa422d2127bd6005cb774bb12acf8ea4c6
+            undertow:
+                rationale: Part of the first base-runtime prototype.
+                ref: 94bc8439f6520a746f2985402bb15cb884cc10a4
+            unicode-ucd:
+                rationale: Part of the first base-runtime prototype.
+                ref: 32802022cc9386941318f1326cfc6d19446f26e1
+            uniconvertor:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5e9363be6abb52e6ec690edd264237b0aff3c0cd
+            unixODBC:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3af8c7577fbfa9844c774c3968833027d1f10f21
+            unzip:
+                rationale: Part of the first base-runtime prototype.
+                ref: 45bcfca8da28de7afb3321edc8510528b14dc7b6
+            upower:
+                rationale: Part of the first base-runtime prototype.
+                ref: 82df6a87c301fdc664b90ea8a8467d6acd47ee7a
+            uriparser:
+                rationale: Part of the first base-runtime prototype.
+                ref: a2faa9b58f26143de8b822bfc401f22db04cf3af
+            urw-fonts:
+                rationale: Part of the first base-runtime prototype.
+                ref: eca85f040552976ebccc23bd2b50bf89bf5ace2e
+            usbredir:
+                rationale: Part of the first base-runtime prototype.
+                ref: d3b0697e61b469ab7ce85142340e80ad46e1cf06
+            userspace-rcu:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3d36ec25907dda7b5ae409e19b0b5dd89f357202
+            ustr:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6df9573ff264c9a92f98cd56780cbe738429abed
+            uthash:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0ea0b7fe45f4e7f0a0cac73b3b2ee1bb3dc802ac
+            util-linux:
+                rationale: Part of the first base-runtime prototype.
+                ref: 208d8b62bd00c46992ba10b681201ce7387436a8
+            uuid:
+                rationale: Part of the first base-runtime prototype.
+                ref: 051bd3312591beebde8231d4352a756abf7ab29e
+            uw-imap:
+                rationale: Part of the first base-runtime prototype.
+                ref: cc5fe59993b7202478dc4b64c15eaa30f4f3c21a
+            v4l-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7fb00df7db17f782d45396522776d48cef6967a3
+            vala:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2f8bc4db6b33de859a352841b6ee3b1733d95ebd
+            valgrind:
+                rationale: Part of the first base-runtime prototype.
+                ref: 01ba3af2c660d94e3542330d971a41b19ffdb8de
+            velocity:
+                rationale: Part of the first base-runtime prototype.
+                ref: f86682d5b4b0f911320aade26a8dbba60007ec45
+            velocity-tools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 098768af509b04d80c4eb9e7a1d6f85451faf710
+            vim:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8512572e9c02f1214538c01d837682bf5170008f
+            virglrenderer:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2fb695b72e74b8f48363e62e1ba462d211a3e843
+            volume_key:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7b2adf2f44578202a76ee962a25aee133292ff09
+            vorbis-java:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2b201f89fd6f29331bea31ac42031dc974042067
+            vsftpd:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8d113be5023bcc5625fa0ee5167198d7305eadc3
+            vte291:
+                rationale: Part of the first base-runtime prototype.
+                ref: ae11908445beadb11b3881ec21e30196f43834e0
+            vte3:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1e08e04f56722d17b577bb38d89f94d350dd2c20
+            w3m:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5bde7d97cf9ffd67d8d612def27bee49cf5e753c
+            wavpack:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0daa6ae8d8aa6af26e15783860393dce5c6cd0f0
+            wayland:
+                rationale: Part of the first base-runtime prototype.
+                ref: da5857bdcde12cb340668d3ffe5f54d132c6582a
+            wayland-protocols:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8195ffd1af49d1037eb0b8df24e7be973888386c
+            web-assets:
+                rationale: Part of the first base-runtime prototype.
+                ref: 645b542ce91aab4f27bec30aa4e24146753af774
+            webkitgtk3:
+                rationale: Part of the first base-runtime prototype.
+                ref: c64521c782468bfc7390d4b292c11311629e24c4
+            webkitgtk4:
+                rationale: Part of the first base-runtime prototype.
+                ref: 77726db5028568e96e8d7450fb69f9f2c3a09d07
+            webrtc-audio-processing:
+                rationale: Part of the first base-runtime prototype.
+                ref: bd9f6cbbd20e7eac70b495a93a71dae3b8d4ded2
+            weld-api:
+                rationale: Part of the first base-runtime prototype.
+                ref: ca66f2a9f5966e34a5bf17d082a9223c9a144620
+            weld-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: 259c66ab2869c953c51fe42e1d758130bd77c5dd
+            weld-parent:
+                rationale: Part of the first base-runtime prototype.
+                ref: f7feb3f1f227943799011973475424cec7afa8bd
+            wget:
+                rationale: Part of the first base-runtime prototype.
+                ref: d52870c88757cca45703a7f0e30c1e4489f01f24
+            which:
+                rationale: Part of the first base-runtime prototype.
+                ref: 98b28b26d8b599a9cfffbba41db52dbd24f6829c
+            wildfly-build-tools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 73e9076b4185ad3d6e8d59131ef0ec64123404f4
+            wildfly-common:
+                rationale: Part of the first base-runtime prototype.
+                ref: dcb7b113808cc266468e7634edb79213e2e90040
+            wildfly-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5086753678f18f82f823b02a6b2808981fc8bc67
+            wildfly-elytron:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9b38f5abe518fff0ad5c91a8ff7f9039aa23efc6
+            wildfly-security-manager:
+                rationale: Part of the first base-runtime prototype.
+                ref: d6c098d0a183eef6c3af82d0f6e5402b89dbb55e
+            wildmidi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7f639076f558a6aac2636c4fac03b1d2f6a03156
+            wireless-tools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 765d3a0db1c7407bfb856041de288c7008709fc9
+            wireshark:
+                rationale: Part of the first base-runtime prototype.
+                ref: d123d4dd1de8a3817461986daef48c5d867ac08d
+            woodstox-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7851359abdb81b5bc34d2a94ea76ebd2a82aea5a
+            words:
+                rationale: Part of the first base-runtime prototype.
+                ref: c11692cb9bec7bf80da88065d84abb51c8d8575c
+            ws-commons-util:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8144b99e2aa10f67df3f35448c1169455890edeb
+            wsdl4j:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3af6ba929ddffa2a123aca65150fe250dc325b22
+            ws-jaxme:
+                rationale: Part of the first base-runtime prototype.
+                ref: c3e243a0c48355c902550f5011219fa213c909e0
+            wxGTK3:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7793bd74b23d85b41621250a01f3495bfeef74f5
+            wxGTK:
+                rationale: Part of the first base-runtime prototype.
+                ref: f5200a1afa2bd45e3784f7312d9f96485ca18648
+            xalan-j2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 0c1258ada5c02f2108ddcca4389e57b289a09bd4
+            xapian-bindings:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1cfc44b09f4bab4bf9a26d754a1b57eb138b9df8
+            xapian-core:
+                rationale: Part of the first base-runtime prototype.
+                ref: 915749ffb9b9dd4a814479848c6be7c03ef8d307
+            xapool:
+                rationale: Part of the first base-runtime prototype.
+                ref: c2e1c11703ef7d0fcb956611e5da9eb527e934d8
+            Xaw3d:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7227923775940bf22a4e5617ff9ff26bc33c3c5a
+            xbean:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3b718cb885ed7d809fc1f48ed93a3ce03248b26f
+            xcb-proto:
+                rationale: Part of the first base-runtime prototype.
+                ref: 66890fce02fcce0cb56af76811e50255ae4a8c8f
+            xcb-util:
+                rationale: Part of the first base-runtime prototype.
+                ref: 8e680b08a4d676c37f529dbc869c0f45aa7d8adc
+            xcb-util-image:
+                rationale: Part of the first base-runtime prototype.
+                ref: eeb0d2865d97038d3519f267c73b3950d854348f
+            xcb-util-keysyms:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3e6e1d2a2ea7b8e42e818f8e7e646f12c1c47446
+            xcb-util-renderutil:
+                rationale: Part of the first base-runtime prototype.
+                ref: 300344982dec829e23b06bfa18ad46169e1bf0a3
+            xcb-util-wm:
+                rationale: Part of the first base-runtime prototype.
+                ref: e1f98fc5a63fedf2760ec035c1581f0a86b35bbe
+            xdg-user-dirs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 19c960a754b50d9583cac7c4b95f2867ca0b895e
+            xdg-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: c4bcf98d867c492d71f5ef5aabad20256e542437
+            xemacs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 155946898a150788745c77b3245fe09028339425
+            xemacs-packages-base:
+                rationale: Part of the first base-runtime prototype.
+                ref: 568d806f47f1a1b59076b6caa0cb6b7706300b31
+            xemacs-packages-extra:
+                rationale: Part of the first base-runtime prototype.
+                ref: b263b5086ee22b6e1d69601f6439c9c34927a8b7
+            xen:
+                rationale: Part of the first base-runtime prototype.
+                ref: 39e256479c3f2a5bae2b58929d6939f51dd5edb4
+            xerces-c:
+                rationale: Part of the first base-runtime prototype.
+                ref: 30b0ad0eca758b16304f2fad39d24cbb42850f2f
+            xerces-j2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 368c5e8cd4bca04e623820a10905df29654762a6
+            xfig:
+                rationale: Part of the first base-runtime prototype.
+                ref: fecb81efff15308b722aaf8bbb75c27c5ad8f587
+            xfsprogs:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4ea7e32a8bffb61e931a9c20bd6dcd91cd29ce52
+            xhtml1-dtds:
+                rationale: Part of the first base-runtime prototype.
+                ref: 06caed9c5c84e144a8c822aa8014b70ee62627be
+            xkeyboard-config:
+                rationale: Part of the first base-runtime prototype.
+                ref: e9748c83bd144948a9adbe48141844dc176f0e9a
+            xmlbeans:
+                rationale: Part of the first base-runtime prototype.
+                ref: 108838f362481cb1b53067ccf579c13e3cfdffd0
+            xmlbeans-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 80dca352a2ede824ec6f491511febb30a70a328a
+            xml-commons-apis:
+                rationale: Part of the first base-runtime prototype.
+                ref: a113e3ee8deb5e0feb35cbd21f35ec5a056239d6
+            xml-commons-resolver:
+                rationale: Part of the first base-runtime prototype.
+                ref: f5610f8b90e9dacc6865c531499c919c3ee9b9e6
+            xmlgraphics-commons:
+                rationale: Part of the first base-runtime prototype.
+                ref: c11873e748c68a2c482e9716809812d3013b717b
+            xml-maven-plugin:
+                rationale: Part of the first base-runtime prototype.
+                ref: 37c91696971d6c85f41a0b74c2dd81376ee5abf2
+            xmlrpc:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7df5e8828a1b1426c06794f9624058fb5d1b814b
+            xmlrpc-c:
+                rationale: Part of the first base-runtime prototype.
+                ref: e0d259d27132f58dd58c7a0ea8d05d820772bdcc
+            xml-security:
+                rationale: Part of the first base-runtime prototype.
+                ref: e2ffd59794e3fbe2fc45598c0ab3fb4d7b84c00c
+            xmlstarlet:
+                rationale: Part of the first base-runtime prototype.
+                ref: 6348ce016b51f78f5b37e413091d45a082bc099d
+            xmlstreambuffer:
+                rationale: Part of the first base-runtime prototype.
+                ref: bdf7707ba33c6d236f5bf63ff6a2b29cc7a2464b
+            xml-stylebook:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7e1e830b1fad1ad90d90e980d490309e36bef89d
+            xmlto:
+                rationale: Part of the first base-runtime prototype.
+                ref: b2dc2deae42d2786b8992bcf1946027cdc3a9576
+            xmltoman:
+                rationale: Part of the first base-runtime prototype.
+                ref: fe389d7888f50eb0db58224b3765e481d9f0cfab
+            xmltool:
+                rationale: Part of the first base-runtime prototype.
+                ref: fbfdea6cc5c1d619feabc171cce876f1dd16bd80
+            xmlunit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4741eb7e6b64c51c5744d59d4b66f0eaa20b5e2b
+            xmms:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2adce75ee134745c5781ee0a6a02701e55bcf9aa
+            xmpcore:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7570ae43d321a1e6772ff7338ba89c0f7ac52f82
+            xmvn:
+                rationale: Part of the first base-runtime prototype.
+                ref: 271ff426093939b8ae78a993d01f5247d9e9449a
+            xnio:
+                rationale: Part of the first base-runtime prototype.
+                ref: 16a670d74a23ef3f8ba38f88ebf09ea391760196
+            xom:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4044785d7f40d24db6380c48de61a82b4a086e55
+            xorg-x11-apps:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9564d7605d99a20c54f84cc7812a1f28cbe6f4fd
+            xorg-x11-drv-dummy:
+                rationale: Part of the first base-runtime prototype.
+                ref: d65816258de08bb1b971f17c699aa78539682dc8
+            xorg-x11-fonts:
+                rationale: Part of the first base-runtime prototype.
+                ref: 837dcb3600e185d2def75eb82fed2bc14199d46b
+            xorg-x11-font-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 08a2ce03b918e0fbca30e0741144a6d2a0f2b810
+            xorg-x11-proto-devel:
+                rationale: Part of the first base-runtime prototype.
+                ref: d6c6ab52edeb52aae08a5eb201e3de1b34c97dc3
+            xorg-x11-server:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9536f6a6e666356735fbfa4ceae7a177bb11b5ba
+            xorg-x11-server-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1ede7bc5cf734a5be506b0d4089a9d40ffad76a4
+            xorg-x11-util-macros:
+                rationale: Part of the first base-runtime prototype.
+                ref: e9993e45f9a4c19a2617c68abf8669e12bffc840
+            xorg-x11-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 02b764494c5e8dbbf79c879ff0ea14545cae3f23
+            xorg-x11-xauth:
+                rationale: Part of the first base-runtime prototype.
+                ref: 16affd05f2abef3d6b8a3e145c4ba67d586a21ae
+            xorg-x11-xbitmaps:
+                rationale: Part of the first base-runtime prototype.
+                ref: 4f4dbf2484331f7ca73e95fedb48eb523007e1a4
+            xorg-x11-xinit:
+                rationale: Part of the first base-runtime prototype.
+                ref: 133329260e14f83b9b4ab89ce8ad993f9f8cf9c2
+            xorg-x11-xkb-utils:
+                rationale: Part of the first base-runtime prototype.
+                ref: 2c5cb7513ecfcd6382fc52ecf819a5e1dffe03c8
+            xorg-x11-xtrans-devel:
+                rationale: Part of the first base-runtime prototype.
+                ref: 48e5483a02d2e718e53d5965d6bf8039c9f29793
+            xpp2:
+                rationale: Part of the first base-runtime prototype.
+                ref: 1b4f63bda1108685fb3acbacd024f9fe5b2af250
+            xpp3:
+                rationale: Part of the first base-runtime prototype.
+                ref: 81a5715016be2aac121e2c5adb6a2a04195e98ca
+            xsom:
+                rationale: Part of the first base-runtime prototype.
+                ref: 355832e6caa7cd040dc776f81a41b5389f22869b
+            xstream:
+                rationale: Part of the first base-runtime prototype.
+                ref: f1918db87a3074c40187dedd43fd02214a7bfa74
+            xz:
+                rationale: Part of the first base-runtime prototype.
+                ref: e94ff72743fc7fa33f138512b3f358660014d38e
+            xz-java:
+                rationale: Part of the first base-runtime prototype.
+                ref: 266843ca2db62e66919fc9faab57df4b0a871b6f
+            yajl:
+                rationale: Part of the first base-runtime prototype.
+                ref: b12b521416297dfd4baf3ce4bf646815700d134b
+            yasm:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5e0c083d7d565b5877fe0be4b2626942c3bf70d6
+            yecht:
+                rationale: Part of the first base-runtime prototype.
+                ref: b838fb175092ad1c7856cdc2a25fa385a7d20310
+            yelp-tools:
+                rationale: Part of the first base-runtime prototype.
+                ref: 7f95f65c777e8e7d3dee2769569c398211828384
+            yelp-xsl:
+                rationale: Part of the first base-runtime prototype.
+                ref: 868375ca1fbbbc1562d668f7efa3a78574539e8f
+            zbar:
+                rationale: Part of the first base-runtime prototype.
+                ref: b84eafaaf25ee335240dcc093c43e71a2bcffdaa
+            zinc:
+                rationale: Part of the first base-runtime prototype.
+                ref: e56442a8ad55f0363dbeaac97cf0c0765aed917d
+            zip:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5566eb5c53bb6fbbf2739dba497efe92b27d028e
+            zlib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 3cc7d30a3b3c7ae44287b948e4e51357e9e44b44
+            zvbi:
+                rationale: Part of the first base-runtime prototype.
+                ref: 5327124c9654a1314ba3c59f04b907b7bfd3b1c9
+            zxing:
+                rationale: Part of the first base-runtime prototype.
+                ref: 17127a6775b6daa858fdefbe70bb240a3d1f9cc0
+            zziplib:
+                rationale: Part of the first base-runtime prototype.
+                ref: 9dc376125aa802edccfdab920b0bf66271b2454a

--- a/examples-testdata/jargon.txt
+++ b/examples-testdata/jargon.txt
@@ -1,4 +1,3 @@
 modularity
 enablement
 multilib
-runtime

--- a/examples-testdata/jargon.txt
+++ b/examples-testdata/jargon.txt
@@ -1,0 +1,4 @@
+modularity
+enablement
+multilib
+runtime

--- a/examples-testdata/params-checkmmd.yaml
+++ b/examples-testdata/params-checkmmd.yaml
@@ -1,0 +1,2 @@
+modulemd: 'examples-modulemd/base-runtime.yaml'
+jargonfile: 'examples-testdata/jargon.txt'


### PR DESCRIPTION
This commit introduces a "jargon file" as an extension to the spell checker's dictionary, and ignores spelling warnings corresponding to the module name. It also includes an avocado parameter yaml and the current version of the base-runtime modulemd as examples.