### PR TITLE
Fixes #7: Calling check_modulemd.py with absolute path.

### DIFF
--- a/run-checkmmd.sh
+++ b/run-checkmmd.sh
@@ -22,9 +22,10 @@ do
       ;;
   esac
 done
-  
 
-cmd="avocado run ./check_modulemd.py"
+CHECK_MODULE_DIR=$(dirname $0)
+
+cmd="avocado run $CHECK_MODULE_DIR/check_modulemd.py"
 
 if [[ $DEBUG = true ]]
 then


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This should fix issue if run-checkmmd.sh is called in absolute or relative path.