### PR TITLE
link to root artifactsdir in taskotron

### DIFF
--- a/process_avocado_results.py
+++ b/process_avocado_results.py
@@ -55,10 +55,10 @@ def run(item, item_type, checkname, workdir='.', artifactsdir='artifacts'):
     results = read_results(workdir)
 
     # 2. Store log
-    log_path = store_logs(workdir, artifactsdir)
+    store_logs(workdir, artifactsdir)
 
     # 3. Massage avocado results into a format suitable for resultsdb/taskotron
-    details = list(massage_results(results, checkname, item, item_type, log_path))
+    details = list(massage_results(results, checkname, item, item_type, artifactsdir))
     output = check.export_YAML(details)
     return output
 


### PR DESCRIPTION
Instead of linking to results.json file. This makes it easier to
navigate and inpect other files present in the artifactsdir.

----

This is an attempt to resolve [T954](https://phab.qa.fedoraproject.org/T954), because @contyk claimed you'd prefer linking to the root artifacts directory instead of `results.json`. The provided should patch *should* do it, but I'm not completely sure. Please push to `develop` first, and we'll see the next time `modulemd` is scheduled on [taskotron-dev](http://taskotron-dev.fedoraproject.org/).