### PR TITLE
strip trailing ;run-XXXX from avocado job IDs

### DIFF
--- a/process_avocado_results.py
+++ b/process_avocado_results.py
@@ -37,6 +37,7 @@ def sanitize(testname):
     """
     testname = testname.split('-', 1)[-1]    # Strip off leading 'XX-'
     testname = testname.replace('.py:', '.') # Remove filename suffixes
+    testname = testname.rsplit(';run-', 1)[0] # Strip off trailing ';run-XXXX'
     return testname
 
 


### PR DESCRIPTION
I believe this will resolve issue #12, but I don't have a good way to properly test it.