### PR TITLE
pdc-client package now installs python3 version of the module by defa…

### DIFF
--- a/runtask.yml
+++ b/runtask.yml
@@ -9,7 +9,7 @@ input:
 
 environment:
     rpm:
-        - pdc-client
+        - python2-pdc-client
         - python2-aexpect
         - python2-modulemd
         - python2-requests


### PR DESCRIPTION
…ult. We need python2 one.